### PR TITLE
Fixed explain component on start page

### DIFF
--- a/frontend/components/utils/Explain.vue
+++ b/frontend/components/utils/Explain.vue
@@ -3,7 +3,7 @@
         v-model="isVisible"
         trigger="click"
         :title="displayTitle"
-        :overlay-style="{ width: '200px' }"
+        :overlay-style="{ width: '200px', zIndex: '35' }"
         :get-popup-container="() => $el.parentElement"
         overlay-class-name="ExplainOverlay"
         :placement="placement"


### PR DESCRIPTION
closes #20 

![Screenshot 2022-01-20 at 14 12 19](https://user-images.githubusercontent.com/30908158/150345480-c85268f1-4b59-4726-8ff7-b1a76ac8df3b.png)

