### PR TITLE
Investigate deploy pipelines state after move

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -10,7 +10,7 @@ data:
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
-          value: https://github.com/sidestream-tech/auction-ui
+          value: https://github.com/sidestream-tech/unified-auctions-ui
       path_to_dockerfile: frontend/Dockerfile
       path_to_context: ./
       build_args:
@@ -47,7 +47,7 @@ data:
         - "pr-${DRONE_PULL_REQUEST}"
       labels:
         - key: org.opencontainers.image.source
-          value: https://github.com/sidestream-tech/auction-ui
+          value: https://github.com/sidestream-tech/unified-auctions-ui
       path_to_dockerfile: frontend/Dockerfile
       path_to_context: ./
       build_args:
@@ -64,13 +64,13 @@ data:
           - pull_request
 
     # frontend-makerdao:$RELEASE_TAG
-    - name: publish-frontend-makerdao
+    - name: publish-frontend-makerdao-on-tag
       repository: ghcr.io/sidestream-tech/auction-ui/frontend-makerdao
       tags:
         - "${DRONE_TAG}"
       labels:
         - key: org.opencontainers.image.source
-          value: https://github.com/sidestream-tech/auction-ui
+          value: https://github.com/sidestream-tech/unified-auctions-ui
       path_to_dockerfile: frontend/Dockerfile
       path_to_context: ./
       build_args:
@@ -86,7 +86,30 @@ data:
         event:
           - tag
 
-    # bot-twitter:main and frontend:$MAIN_COMMIT_SHA
+    # frontend:$RELEASE_TAG
+    - name: publish-frontend-on-tag
+      repository: ghcr.io/sidestream-tech/auction-ui/frontend
+      tags:
+        - "${DRONE_TAG}"
+      labels:
+        - key: org.opencontainers.image.source
+          value: https://github.com/sidestream-tech/unified-auctions-ui
+      path_to_dockerfile: frontend/Dockerfile
+      path_to_context: ./
+      build_args:
+        - key: PRODUCTION_DOMAIN
+          value_from_secret: auction-ui/auctions.makerdao.network/frontend/production_domain
+        - key: INFURA_PROJECT_ID
+          value_from_secret: auction-ui/auctions.makerdao.network/frontend/infura_project_id
+        - key: CONTACT_EMAIL
+          value_from_secret: auction-ui/auctions.makerdao.network/frontend/contact_email
+      tags_to_cache_from:
+        - "main"
+      trigger:
+        event:
+          - tag
+
+    # bot-twitter:main and bot-twitter:$MAIN_COMMIT_SHA
     - name: publish-bot-twitter-merge-main
       repository: ghcr.io/sidestream-tech/auction-ui/bot-twitter
       tags:
@@ -94,7 +117,7 @@ data:
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
-          value: https://github.com/sidestream-tech/auction-ui
+          value: https://github.com/sidestream-tech/unified-auctions-ui
       path_to_dockerfile: bot-twitter/Dockerfile
       path_to_context: ./
       tags_to_cache_from:
@@ -123,7 +146,7 @@ data:
         - "${DRONE_TAG}"
       labels:
         - key: org.opencontainers.image.source
-          value: https://github.com/sidestream-tech/auction-ui
+          value: https://github.com/sidestream-tech/unified-auctions-ui
       path_to_dockerfile: bot-twitter/Dockerfile
       path_to_context: ./
       tags_to_cache_from:
@@ -140,7 +163,7 @@ data:
         - "pr-${DRONE_PULL_REQUEST}"
       labels:
         - key: org.opencontainers.image.source
-          value: https://github.com/sidestream-tech/auction-ui
+          value: https://github.com/sidestream-tech/unified-auctions-ui
       path_to_dockerfile: bot-twitter/Dockerfile
       path_to_context: ./
       tags_to_cache_from:
@@ -154,6 +177,28 @@ data:
       depends_on:
         - publish-bot-twitter-merge-main
         - publish-frontend-merge-main
+      trigger:
+        event:
+          - push
+        branch:
+          - main
+      settings:
+        helm_root_path: kubernetes/helm
+        aws_target_eks_cluster_name: eks-cluster-sidestream
+        aws_ssm_path_to_base64_encoded_secrets_yaml: auction-ui/secrets.yaml
+        value_files:
+        - values.yaml
+        - values.override_main.auction-ui.k8s.sidestream.tech.yaml
+        target_namespace: "auction-ui-main"
+        release_name: "auction-ui"
+        values_to_set:
+          - frontend.deployment.tag=$DRONE_COMMIT_SHA
+          - botTwitter.deployment.tag=$DRONE_COMMIT_SHA
+
+    - name: deploy-production.auction-ui.k8s.sidestream.tech
+      depends_on:
+        - publish-bot-twitter-on-tag
+        - publish-frontend-on-tag
       trigger:
         event:
           - push

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,9 +86,9 @@ data:
         event:
           - tag
 
-    # frontend:$RELEASE_TAG
-    - name: publish-frontend-on-tag
-      repository: ghcr.io/sidestream-tech/auction-ui/frontend
+    # frontend-production:$RELEASE_TAG
+    - name: publish-frontend-production-on-tag
+      repository: ghcr.io/sidestream-tech/auction-ui/frontend-production
       tags:
         - "${DRONE_TAG}"
       labels:
@@ -98,11 +98,11 @@ data:
       path_to_context: ./
       build_args:
         - key: PRODUCTION_DOMAIN
-          value_from_secret: auction-ui/auctions.makerdao.network/frontend/production_domain
+          value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/production_domain
         - key: INFURA_PROJECT_ID
-          value_from_secret: auction-ui/auctions.makerdao.network/frontend/infura_project_id
+          value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/infura_project_id
         - key: CONTACT_EMAIL
-          value_from_secret: auction-ui/auctions.makerdao.network/frontend/contact_email
+          value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/contact_email
       tags_to_cache_from:
         - "main"
       trigger:
@@ -198,20 +198,18 @@ data:
     - name: deploy-production.auction-ui.k8s.sidestream.tech
       depends_on:
         - publish-bot-twitter-on-tag
-        - publish-frontend-on-tag
+        - publish-frontend-production-on-tag
       trigger:
         event:
-          - push
-        branch:
-          - main
+          - tag
       settings:
         helm_root_path: kubernetes/helm
         aws_target_eks_cluster_name: eks-cluster-sidestream
         aws_ssm_path_to_base64_encoded_secrets_yaml: auction-ui/secrets.yaml
         value_files:
         - values.yaml
-        - values.override_main.auction-ui.k8s.sidestream.tech.yaml
-        target_namespace: "auction-ui-main"
+        - values.override_production.auction-ui.k8s.sidestream.tech.yaml
+        target_namespace: "auction-ui-production"
         release_name: "auction-ui"
         values_to_set:
           - frontend.deployment.tag=$DRONE_COMMIT_SHA

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ data:
     - name: publish-frontend-merge-main
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend
       tags:
-        - "main"
+        # - "main"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -25,8 +25,8 @@ data:
       trigger:
         event:
           - push
-        branch:
-          - main
+        # branch:
+        #   - main
 
     # frontend no tag, just test production build
     - name: build-frontend-to-test-production-build
@@ -92,7 +92,7 @@ data:
     - name: publish-bot-twitter-merge-main
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
-        - "main"
+        # - "main"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -104,8 +104,8 @@ data:
       trigger:
         event:
           - push
-        branch:
-          - main
+        # branch:
+        #   - main
 
     # bot-twitter no tag, just test production build
     - name: build-bot-twitter-to-test-production-build

--- a/.drone.yml
+++ b/.drone.yml
@@ -67,7 +67,7 @@ data:
     - name: publish-frontend-makerdao-on-tag
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend-makerdao
       tags:
-        - "${DRONE_TAG}"
+        # - "${DRONE_TAG}"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -122,7 +122,7 @@ data:
     - name: publish-bot-twitter-on-tag
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
-        - "${DRONE_TAG}"
+        # - "${DRONE_TAG}"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ data:
     - name: publish-frontend-merge-main
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend
       tags:
-        # - "main"
+        - "main"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -25,8 +25,8 @@ data:
       trigger:
         event:
           - push
-        # branch:
-        #   - main
+        branch:
+          - main
 
     # frontend no tag, just test production build
     - name: build-frontend-to-test-production-build
@@ -67,8 +67,7 @@ data:
     - name: publish-frontend-makerdao-on-tag
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend-makerdao
       tags:
-        # - "${DRONE_TAG}"
-        - "${DRONE_COMMIT_SHA}"
+        - "${DRONE_TAG}"
       labels:
         - key: org.opencontainers.image.source
           value: https://github.com/sidestream-tech/unified-auctions-ui
@@ -86,13 +85,12 @@ data:
       trigger:
         event:
           - tag
-          - push
 
     # bot-twitter:main and bot-twitter:$MAIN_COMMIT_SHA
     - name: publish-bot-twitter-merge-main
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
-        # - "main"
+        - "main"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -104,8 +102,8 @@ data:
       trigger:
         event:
           - push
-        # branch:
-        #   - main
+        branch:
+          - main
 
     # bot-twitter no tag, just test production build
     - name: build-bot-twitter-to-test-production-build
@@ -122,8 +120,7 @@ data:
     - name: publish-bot-twitter-on-tag
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
-        # - "${DRONE_TAG}"
-        - "${DRONE_COMMIT_SHA}"
+        - "${DRONE_TAG}"
       labels:
         - key: org.opencontainers.image.source
           value: https://github.com/sidestream-tech/unified-auctions-ui
@@ -134,7 +131,6 @@ data:
       trigger:
         event:
           - tag
-          - push
 
     # bot-twitter:pr-$PULL_REQUEST_NUMBER
     - name: publish-bot-twitter-on-pr-push
@@ -161,8 +157,8 @@ data:
       trigger:
         event:
           - push
-        # branch:
-        #   - main
+        branch:
+          - main
       settings:
         helm_root_path: kubernetes/helm
         aws_target_eks_cluster_name: eks-cluster-sidestream
@@ -182,7 +178,6 @@ data:
         - publish-frontend-makerdao-on-tag
       trigger:
         event:
-          - push
           - tag
       settings:
         helm_root_path: kubernetes/helm
@@ -196,8 +191,6 @@ data:
         values_to_set:
           - frontend.deployment.tag=$DRONE_TAG
           - botTwitter.deployment.tag=$DRONE_TAG
-          - frontend.deployment.tag=$DRONE_COMMIT_SHA
-          - botTwitter.deployment.tag=$DRONE_COMMIT_SHA
 
   in_development_image_pipelines:
     - name: core-lint-build

--- a/.drone.yml
+++ b/.drone.yml
@@ -90,8 +90,7 @@ data:
     - name: publish-frontend-production-on-tag
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend-production
       tags:
-        # - "${DRONE_TAG}"
-        - "${DRONE_COMMIT_SHA}"
+        - "${DRONE_TAG}"
       labels:
         - key: org.opencontainers.image.source
           value: https://github.com/sidestream-tech/unified-auctions-ui
@@ -108,8 +107,7 @@ data:
         - "main"
       trigger:
         event:
-          # - tag
-          - push
+          - tag
 
     # bot-twitter:main and bot-twitter:$MAIN_COMMIT_SHA
     - name: publish-bot-twitter-merge-main
@@ -145,8 +143,7 @@ data:
     - name: publish-bot-twitter-on-tag
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
-        # - "${DRONE_TAG}"
-        - "${DRONE_COMMIT_SHA}"
+        - "${DRONE_TAG}"
       labels:
         - key: org.opencontainers.image.source
           value: https://github.com/sidestream-tech/unified-auctions-ui
@@ -156,8 +153,7 @@ data:
         - "main"
       trigger:
         event:
-          # - tag
-          - push
+          - tag
 
     # bot-twitter:pr-$PULL_REQUEST_NUMBER
     - name: publish-bot-twitter-on-pr-push
@@ -205,8 +201,7 @@ data:
         - publish-frontend-production-on-tag
       trigger:
         event:
-          # - tag
-          - push
+          - tag
       settings:
         helm_root_path: kubernetes/helm
         aws_target_eks_cluster_name: eks-cluster-sidestream
@@ -217,10 +212,8 @@ data:
         target_namespace: "auction-ui-production"
         release_name: "auction-ui"
         values_to_set:
-          # - frontend.deployment.tag=$DRONE_TAG
-          # - botTwitter.deployment.tag=$DRONE_TAG
-          - frontend.deployment.tag=$DRONE_COMMIT_SHA
-          - botTwitter.deployment.tag=$DRONE_COMMIT_SHA
+          - frontend.deployment.tag=$DRONE_TAG
+          - botTwitter.deployment.tag=$DRONE_TAG
 
   in_development_image_pipelines:
     - name: core-lint-build

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ data:
     - name: publish-frontend-merge-main
       repository: ghcr.io/sidestream-tech/auction-ui/frontend
       tags:
-        # - "main"
+        - "main"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -25,8 +25,8 @@ data:
       trigger:
         event:
           - push
-        # branch:
-        #   - main
+        branch:
+          - main
 
     # frontend no tag, just test production build
     - name: build-frontend-to-test-production-build
@@ -90,7 +90,7 @@ data:
     - name: publish-bot-twitter-merge-main
       repository: ghcr.io/sidestream-tech/auction-ui/bot-twitter
       tags:
-        # - "main"
+        - "main"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -102,8 +102,8 @@ data:
       trigger:
         event:
           - push
-        # branch:
-        #   - main
+        branch:
+          - main
 
     # bot-twitter no tag, just test production build
     - name: build-bot-twitter-to-test-production-build
@@ -157,8 +157,8 @@ data:
       trigger:
         event:
           - push
-        # branch:
-        #   - main
+        branch:
+          - main
       settings:
         helm_root_path: kubernetes/helm
         aws_target_eks_cluster_name: eks-cluster-sidestream

--- a/.drone.yml
+++ b/.drone.yml
@@ -86,29 +86,6 @@ data:
         event:
           - tag
 
-    # frontend-production:$RELEASE_TAG
-    - name: publish-frontend-production-on-tag
-      repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend-production
-      tags:
-        - "${DRONE_TAG}"
-      labels:
-        - key: org.opencontainers.image.source
-          value: https://github.com/sidestream-tech/unified-auctions-ui
-      path_to_dockerfile: frontend/Dockerfile
-      path_to_context: ./
-      build_args:
-        - key: PRODUCTION_DOMAIN
-          value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/production_domain
-        - key: INFURA_PROJECT_ID
-          value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/infura_project_id
-        - key: CONTACT_EMAIL
-          value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/contact_email
-      tags_to_cache_from:
-        - "main"
-      trigger:
-        event:
-          - tag
-
     # bot-twitter:main and bot-twitter:$MAIN_COMMIT_SHA
     - name: publish-bot-twitter-merge-main
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
@@ -198,7 +175,7 @@ data:
     - name: deploy-production.auction-ui.k8s.sidestream.tech
       depends_on:
         - publish-bot-twitter-on-tag
-        - publish-frontend-production-on-tag
+        - publish-frontend-makerdao-on-tag
       trigger:
         event:
           - tag

--- a/.drone.yml
+++ b/.drone.yml
@@ -68,6 +68,7 @@ data:
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend-makerdao
       tags:
         - "${DRONE_TAG}"
+        - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
           value: https://github.com/sidestream-tech/unified-auctions-ui
@@ -85,6 +86,7 @@ data:
       trigger:
         event:
           - tag
+          - push
 
     # bot-twitter:main and bot-twitter:$MAIN_COMMIT_SHA
     - name: publish-bot-twitter-merge-main
@@ -121,6 +123,7 @@ data:
       repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
         - "${DRONE_TAG}"
+        - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
           value: https://github.com/sidestream-tech/unified-auctions-ui
@@ -131,6 +134,7 @@ data:
       trigger:
         event:
           - tag
+          - push
 
     # bot-twitter:pr-$PULL_REQUEST_NUMBER
     - name: publish-bot-twitter-on-pr-push
@@ -157,8 +161,8 @@ data:
       trigger:
         event:
           - push
-        branch:
-          - main
+        # branch:
+        #   - main
       settings:
         helm_root_path: kubernetes/helm
         aws_target_eks_cluster_name: eks-cluster-sidestream
@@ -178,6 +182,7 @@ data:
         - publish-frontend-makerdao-on-tag
       trigger:
         event:
+          - push
           - tag
       settings:
         helm_root_path: kubernetes/helm
@@ -191,6 +196,8 @@ data:
         values_to_set:
           - frontend.deployment.tag=$DRONE_TAG
           - botTwitter.deployment.tag=$DRONE_TAG
+          - frontend.deployment.tag=$DRONE_COMMIT_SHA
+          - botTwitter.deployment.tag=$DRONE_COMMIT_SHA
 
   in_development_image_pipelines:
     - name: core-lint-build

--- a/.drone.yml
+++ b/.drone.yml
@@ -4,7 +4,7 @@ data:
   builds:
     # frontend:main and frontend:$MAIN_COMMIT_SHA
     - name: publish-frontend-merge-main
-      repository: ghcr.io/sidestream-tech/auction-ui/frontend
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend
       tags:
         - "main"
         - "${DRONE_COMMIT_SHA}"
@@ -30,7 +30,7 @@ data:
 
     # frontend no tag, just test production build
     - name: build-frontend-to-test-production-build
-      repository: ghcr.io/sidestream-tech/auction-ui/frontend
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend
       path_to_dockerfile: frontend/Dockerfile
       path_to_context: ./
       tags_to_cache_from:
@@ -42,7 +42,7 @@ data:
     # frontend:pr-$PULL_REQUEST_NUMBER
     - name: publish-frontend-on-pr-push
       target: development
-      repository: ghcr.io/sidestream-tech/auction-ui/frontend
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend
       tags:
         - "pr-${DRONE_PULL_REQUEST}"
       labels:
@@ -65,7 +65,7 @@ data:
 
     # frontend-makerdao:$RELEASE_TAG
     - name: publish-frontend-makerdao-on-tag
-      repository: ghcr.io/sidestream-tech/auction-ui/frontend-makerdao
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend-makerdao
       tags:
         - "${DRONE_TAG}"
       labels:
@@ -88,7 +88,7 @@ data:
 
     # frontend-production:$RELEASE_TAG
     - name: publish-frontend-production-on-tag
-      repository: ghcr.io/sidestream-tech/auction-ui/frontend-production
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/frontend-production
       tags:
         # - "${DRONE_TAG}"
         - "${DRONE_COMMIT_SHA}"
@@ -113,7 +113,7 @@ data:
 
     # bot-twitter:main and bot-twitter:$MAIN_COMMIT_SHA
     - name: publish-bot-twitter-merge-main
-      repository: ghcr.io/sidestream-tech/auction-ui/bot-twitter
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
         - "main"
         - "${DRONE_COMMIT_SHA}"
@@ -132,7 +132,7 @@ data:
 
     # bot-twitter no tag, just test production build
     - name: build-bot-twitter-to-test-production-build
-      repository: ghcr.io/sidestream-tech/auction-ui/bot-twitter
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       path_to_dockerfile: bot-twitter/Dockerfile
       path_to_context: ./
       tags_to_cache_from:
@@ -143,7 +143,7 @@ data:
 
     # bot-twitter:$RELEASE_TAG
     - name: publish-bot-twitter-on-tag
-      repository: ghcr.io/sidestream-tech/auction-ui/bot-twitter
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
         # - "${DRONE_TAG}"
         - "${DRONE_COMMIT_SHA}"
@@ -162,7 +162,7 @@ data:
     # bot-twitter:pr-$PULL_REQUEST_NUMBER
     - name: publish-bot-twitter-on-pr-push
       target: development
-      repository: ghcr.io/sidestream-tech/auction-ui/bot-twitter
+      repository: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter
       tags:
         - "pr-${DRONE_PULL_REQUEST}"
       labels:
@@ -226,7 +226,7 @@ data:
     - name: core-lint-build
       type: kubernetes
       depends_on: [publish-frontend-on-pr-push]
-      image: ghcr.io/sidestream-tech/auction-ui/frontend:pr-${DRONE_PULL_REQUEST}
+      image: ghcr.io/sidestream-tech/unified-auctions-ui/frontend:pr-${DRONE_PULL_REQUEST}
       workdir: /core
       steps_parallel:
         - name: lint
@@ -239,7 +239,7 @@ data:
     - name: frontend-lint-test
       type: kubernetes
       depends_on: [publish-frontend-on-pr-push]
-      image: ghcr.io/sidestream-tech/auction-ui/frontend:pr-${DRONE_PULL_REQUEST}
+      image: ghcr.io/sidestream-tech/unified-auctions-ui/frontend:pr-${DRONE_PULL_REQUEST}
       workdir: /frontend
       steps_parallel:
         - name: lint
@@ -252,7 +252,7 @@ data:
     - name: bot-twitter-lint
       type: kubernetes
       depends_on: [publish-bot-twitter-on-pr-push]
-      image: ghcr.io/sidestream-tech/auction-ui/bot-twitter:pr-${DRONE_PULL_REQUEST}
+      image: ghcr.io/sidestream-tech/unified-auctions-ui/bot-twitter:pr-${DRONE_PULL_REQUEST}
       workdir: /bot-twitter
       steps_parallel:
         - name: lint

--- a/.drone.yml
+++ b/.drone.yml
@@ -157,8 +157,8 @@ data:
       trigger:
         event:
           - push
-        branch:
-          - main
+        # branch:
+        #   - main
       settings:
         helm_root_path: kubernetes/helm
         aws_target_eks_cluster_name: eks-cluster-sidestream

--- a/.drone.yml
+++ b/.drone.yml
@@ -90,7 +90,8 @@ data:
     - name: publish-frontend-production-on-tag
       repository: ghcr.io/sidestream-tech/auction-ui/frontend-production
       tags:
-        - "${DRONE_TAG}"
+        # - "${DRONE_TAG}"
+        - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
           value: https://github.com/sidestream-tech/unified-auctions-ui
@@ -107,7 +108,8 @@ data:
         - "main"
       trigger:
         event:
-          - tag
+          # - tag
+          - push
 
     # bot-twitter:main and bot-twitter:$MAIN_COMMIT_SHA
     - name: publish-bot-twitter-merge-main
@@ -143,7 +145,8 @@ data:
     - name: publish-bot-twitter-on-tag
       repository: ghcr.io/sidestream-tech/auction-ui/bot-twitter
       tags:
-        - "${DRONE_TAG}"
+        # - "${DRONE_TAG}"
+        - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
           value: https://github.com/sidestream-tech/unified-auctions-ui
@@ -153,7 +156,8 @@ data:
         - "main"
       trigger:
         event:
-          - tag
+          # - tag
+          - push
 
     # bot-twitter:pr-$PULL_REQUEST_NUMBER
     - name: publish-bot-twitter-on-pr-push
@@ -201,7 +205,8 @@ data:
         - publish-frontend-production-on-tag
       trigger:
         event:
-          - tag
+          # - tag
+          - push
       settings:
         helm_root_path: kubernetes/helm
         aws_target_eks_cluster_name: eks-cluster-sidestream
@@ -212,6 +217,8 @@ data:
         target_namespace: "auction-ui-production"
         release_name: "auction-ui"
         values_to_set:
+          # - frontend.deployment.tag=$DRONE_TAG
+          # - botTwitter.deployment.tag=$DRONE_TAG
           - frontend.deployment.tag=$DRONE_COMMIT_SHA
           - botTwitter.deployment.tag=$DRONE_COMMIT_SHA
 

--- a/.drone.yml
+++ b/.drone.yml
@@ -6,7 +6,7 @@ data:
     - name: publish-frontend-merge-main
       repository: ghcr.io/sidestream-tech/auction-ui/frontend
       tags:
-        - "main"
+        # - "main"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -25,8 +25,8 @@ data:
       trigger:
         event:
           - push
-        branch:
-          - main
+        # branch:
+        #   - main
 
     # frontend no tag, just test production build
     - name: build-frontend-to-test-production-build
@@ -90,7 +90,7 @@ data:
     - name: publish-bot-twitter-merge-main
       repository: ghcr.io/sidestream-tech/auction-ui/bot-twitter
       tags:
-        - "main"
+        # - "main"
         - "${DRONE_COMMIT_SHA}"
       labels:
         - key: org.opencontainers.image.source
@@ -102,8 +102,8 @@ data:
       trigger:
         event:
           - push
-        branch:
-          - main
+        # branch:
+        #   - main
 
     # bot-twitter no tag, just test production build
     - name: build-bot-twitter-to-test-production-build

--- a/kubernetes/helm/templates/ingress.yaml
+++ b/kubernetes/helm/templates/ingress.yaml
@@ -9,20 +9,21 @@ metadata:
     cert-manager.io/cluster-issuer: "cloudflare-issuer"
     {{- end }}
 spec:
-  {{- if .Values.ingress.isTlsActivated }}
+  {{- if .Values.ingress.tls }}
   tls:
-  - hosts:
-    - {{ .Values.host }}
-    secretName: {{ .Values.ingress.tlsSecretName }}
+    {{- .Values.ingress.tls | toYaml | nindent 4 }}
   {{- end }}
   rules:
-    - host: {{ required "A host is required for the ingress to work" .Values.host }}
+    {{- $frontendName := .Values.frontend.name }}
+    {{- range .Values.hosts }}
+    - host: {{ required "A host is required for the ingress to work" . }}
       http:
         paths:
         - path: /(.*)
           pathType: Prefix
           backend:
             service:
-              name: {{ .Values.frontend.name }}-service
+              name: {{ $frontendName }}-service
               port:
                 number: 80
+    {{- end }}

--- a/kubernetes/helm/values.override_auctions.makerdao.network.yaml
+++ b/kubernetes/helm/values.override_auctions.makerdao.network.yaml
@@ -1,6 +1,7 @@
 # Value overrides for the deployment to the following host:
 hosts:
 - "auctions.makerdao.network"
+- "unified-auctions.makerdao.com"
 
 frontend:
   deployment:

--- a/kubernetes/helm/values.override_auctions.makerdao.network.yaml
+++ b/kubernetes/helm/values.override_auctions.makerdao.network.yaml
@@ -1,10 +1,6 @@
 # Value overrides for the deployment to the following host:
-host: "auctions.makerdao.network"
-
-ingress:
-  # certificates in this environment are generated and terminated by `auctions.makerdao.network` owners
-  isCertManagerActivated: false
-  isTlsActivated: false
+hosts:
+- "auctions.makerdao.network"
 
 frontend:
   deployment:

--- a/kubernetes/helm/values.override_auctions.makerdao.network.yaml
+++ b/kubernetes/helm/values.override_auctions.makerdao.network.yaml
@@ -9,7 +9,7 @@ ingress:
 frontend:
   deployment:
     # the frontend bakes in environment variables that need to be changed for makerdao,
-    # so we built a second image just for that
+    # so we built a separate image just for that
     image: "frontend-makerdao"
 
 botTwitter:

--- a/kubernetes/helm/values.override_localhost.yaml
+++ b/kubernetes/helm/values.override_localhost.yaml
@@ -1,5 +1,6 @@
 # Value overrides for the deployment to the following host:
-host: "localhost"
+hosts:
+- "localhost"
 
 ingress:
   isCertManagerActivated: false

--- a/kubernetes/helm/values.override_main.auction-ui.k8s.sidestream.tech.yaml
+++ b/kubernetes/helm/values.override_main.auction-ui.k8s.sidestream.tech.yaml
@@ -1,5 +1,13 @@
 # Value overrides for the deployment to the following host:
-host: "main.auction-ui.k8s.sidestream.tech"
+hosts:
+- "main.auction-ui.k8s.sidestream.tech"
+
+ingress:
+  isCertManagerActivated: true
+  tls:
+    - hosts:
+      - "main.auction-ui.k8s.sidestream.tech"
+      secretName: "auction-ui-tls-certificate"
 
 botTwitter:
   secretChamberPath: "auction-ui/main.auction-ui.k8s.sidestream.tech/bot-twitter"

--- a/kubernetes/helm/values.override_production.auction-ui.k8s.sidestream.tech.yaml
+++ b/kubernetes/helm/values.override_production.auction-ui.k8s.sidestream.tech.yaml
@@ -1,0 +1,11 @@
+# Value overrides for the deployment to the following host:
+host: "production.auction-ui.k8s.sidestream.tech"
+
+frontend:
+  deployment:
+    # the frontend bakes in environment variables that need to be changed for makerdao,
+    # so we built a separate image just for that
+    image: "frontend-production"
+
+botTwitter:
+  secretChamberPath: "auction-ui/production.auction-ui.k8s.sidestream.tech/bot-twitter"

--- a/kubernetes/helm/values.override_production.auction-ui.k8s.sidestream.tech.yaml
+++ b/kubernetes/helm/values.override_production.auction-ui.k8s.sidestream.tech.yaml
@@ -1,5 +1,16 @@
 # Value overrides for the deployment to the following host:
-host: "production.auction-ui.k8s.sidestream.tech"
+hosts:
+  - "production.auction-ui.k8s.sidestream.tech"
+  - "auctions.makerdao.network"
+
+ingress:
+  isCertManagerActivated: true
+  # We can only generate a TLS cert for our own domain,
+  # maker needs to take over their domains TLS termination
+  tls:
+    - hosts:
+        - "production.auction-ui.k8s.sidestream.tech"
+      secretName: "auction-ui-tls-certificate"
 
 frontend:
   deployment:

--- a/kubernetes/helm/values.override_production.auction-ui.k8s.sidestream.tech.yaml
+++ b/kubernetes/helm/values.override_production.auction-ui.k8s.sidestream.tech.yaml
@@ -16,7 +16,7 @@ frontend:
   deployment:
     # the frontend bakes in environment variables that need to be changed for makerdao,
     # so we built a separate image just for that
-    image: "frontend-production"
+    image: "frontend-makerdao"
 
 botTwitter:
   secretChamberPath: "auction-ui/production.auction-ui.k8s.sidestream.tech/bot-twitter"

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -7,7 +7,7 @@ images:
   secretName: "sidestream-github"
 
 awsChamberAccountSecretName: "sidestream-tech-chamber-read-secret"
-repoPrefix: "ghcr.io/sidestream-tech/auction-ui/"
+repoPrefix: "ghcr.io/sidestream-tech/unified-auctions-ui/"
 
 frontend:
   name: "frontend"

--- a/kubernetes/helm/values.yaml
+++ b/kubernetes/helm/values.yaml
@@ -1,7 +1,7 @@
 # Default values for auction-ui.
 # This is a YAML-formatted file.
 # Declare variables to be passed into your templates.
-host:
+hosts: null
 
 images:
   secretName: "sidestream-github"
@@ -13,7 +13,7 @@ frontend:
   name: "frontend"
   containerPort: 80
   deployment:
-    tag:
+    tag: null
     image: "frontend"
     pullPolicy: "IfNotPresent"
 
@@ -22,12 +22,11 @@ botTwitter:
   # AWS SSM path for chamber to read secrets for the pods from, e.g., `auction-ui/staging/bot`
   secretChamberPath:
   deployment:
-    tag:
+    tag: null
     image: "bot-twitter"
     pullPolicy: "IfNotPresent"
 
 ingress:
   class: nginx
-  isCertManagerActivated: true
-  isTlsActivated: true
-  tlsSecretName: "auction-ui-tls-certificate"
+  isCertManagerActivated: false
+  tls: null


### PR DESCRIPTION
Closes #56
Closes #25 

This PR adds a continuous deployment of https://production.auction-ui.k8s.sidestream.tech. It is deemed to take over the role of https://auctions.makerdao.network. Right now the deployment is in "stealth mode" - it doesn't consume any API quota or tweet any tweets.

See #25 for the environment limitations. 

In order to test this, the deployment of this env was enabled to be "on push" instead of "on tag". This should be reverted before the merge.
