### PR TITLE
Fixed VueX Fee bug

### DIFF
--- a/frontend/store/auctions.ts
+++ b/frontend/store/auctions.ts
@@ -36,15 +36,18 @@ export const state = (): State => ({
 });
 
 export const getters = {
-    listAuctions(state: State) {
+    listAuctions(state: State): AuctionTransaction[] {
         return Object.values(state.auctionStorage);
     },
     listAuctionTransactions(state: State, getters: any, _rootState: any): AuctionTransaction[] {
         const auctions = Object.values(state.auctionStorage);
-        auctions.forEach(auction => {
-            auction.isRestarting = getters.isAuctionRestarting(auction.id);
+        return auctions.map(auction => {
+            const isRestarting = getters.isAuctionRestarting(auction.id);
+            return {
+                ...auction,
+                isRestarting,
+            };
         });
-        return auctions;
     },
     getAuctionById: (state: State) => (id: string) => {
         return state.auctionStorage[id];
@@ -137,7 +140,6 @@ export const actions = {
     async fetch({ commit, dispatch }: ActionContext<State, State>) {
         commit('setIsFetching', true);
         await dispatch('fetchWithoutLoading');
-        dispatch('fees/setup', null, { root: true });
         if (refetchIntervalId) {
             clearInterval(refetchIntervalId);
         }


### PR DESCRIPTION
closes #84 

The first error message was due to us still calling:
```js
dispatch('fees/setup', null, { root: true });
```
https://github.com/sidestream-tech/unified-auctions-ui/blob/main/frontend/store/auctions.ts#L140

The other issue was that we were trying to mutate the store directly. Before we had a `.map()` function with which we made a new Object, which we then enriched with the restarting state. 

Once I removed the enriching with Fees we no longer made a new object resulting in us trying to mutate the store with `.foreach`, leading to the error. I changed the foreach to a map function which I then exported and everything is now working as intended!