### PR TITLE
Improve indication of restarting auctions

### DIFF
--- a/frontend/components/Auction.vue
+++ b/frontend/components/Auction.vue
@@ -2,6 +2,13 @@
     <TextBlock :title="`Auction #${auctionId}`">
         <Alert v-if="errorText" class="my-3" :message="errorText" type="error" />
         <div v-if="auction">
+            <WalletBlock
+                v-if="!auction.isActive && !auction.isFinished && !walletAddress"
+                class="my-4"
+                :wallet-address="walletAddress"
+                :is-explanations-shown="isExplanationsShown"
+                @connectWallet="$emit('connect')"
+            />
             <RestartBlock
                 v-if="errorText === 'This auction is inactive and must be restarted'"
                 :transaction-fee="auction.restartTransactionFeeETH"
@@ -240,6 +247,7 @@ import Loading from '~/components/common/Loading.vue';
 import Explain from '~/components/utils/Explain.vue';
 import RestartBlock from '~/components/transaction/RestartBlock.vue';
 import TimeTillProfitable from '~/components/utils/TimeTillProfitable.vue';
+import WalletBlock from '~/components/transaction/WalletBlock.vue';
 
 export default Vue.extend({
     name: 'Auction',
@@ -258,6 +266,7 @@ export default Vue.extend({
         Tooltip,
         TimeTillProfitable,
         Popover,
+        WalletBlock,
     },
     props: {
         auction: {

--- a/frontend/components/Auction.vue
+++ b/frontend/components/Auction.vue
@@ -56,7 +56,7 @@
                                 <template v-if="auction.isActive && auction.marketUnitPriceToUnitPriceRatio">
                                     <format-market-value :value="auction.marketUnitPriceToUnitPriceRatio" />
                                 </template>
-                                <span v-else class="opacity-50">Unknown</span>
+                                <span v-else class="opacity-50">Not tradable</span>
                             </td>
                         </tr>
                         <tr>

--- a/frontend/components/Auction.vue
+++ b/frontend/components/Auction.vue
@@ -75,7 +75,19 @@
                             <tr class="bg-gray-100 dark:bg-gray-800">
                                 <td>Auction Price Total</td>
                                 <td>
-                                    <format-currency :value="auction.totalPrice" currency="DAI" />
+                                    <format-currency
+                                        v-if="auction.isActive"
+                                        :value="auction.totalPrice"
+                                        currency="DAI"
+                                    />
+                                    <Popover
+                                        v-else
+                                        placement="top"
+                                        content="Since the auction is not active, there is no total Auction Price for this auction."
+                                        trigger="hover"
+                                    >
+                                        <span class="opacity-50">Unknown</span>
+                                    </Popover>
                                 </td>
                             </tr>
                             <tr class="bg-gray-100 dark:bg-gray-800">
@@ -216,7 +228,7 @@
 <script lang="ts">
 import type { AuctionTransaction } from 'auctions-core/src/types';
 import Vue from 'vue';
-import { Alert, Tooltip } from 'ant-design-vue';
+import { Alert, Tooltip, Popover } from 'ant-design-vue';
 import PriceDropAnimation from './utils/PriceDropAnimation.vue';
 import TextBlock from '~/components/common/TextBlock.vue';
 import TimeTill from '~/components/common/TimeTill.vue';
@@ -245,6 +257,7 @@ export default Vue.extend({
         Alert,
         Tooltip,
         TimeTillProfitable,
+        Popover,
     },
     props: {
         auction: {

--- a/frontend/components/AuctionsTable.vue
+++ b/frontend/components/AuctionsTable.vue
@@ -41,7 +41,9 @@
                 :class="(hoveredRowIndex === index && 'bg-primary text-white dark:bg-primary-dark') || 'text-primary'"
                 class="flex items-center justify-center w-full h-full hover:text-white p-2 whitespace-nowrap"
             >
-                See details
+                <span v-if="record.isFinished">See details</span>
+                <span v-else-if="record.isActive">Participate</span>
+                <span v-else-if="!record.isActive">Restart auction</span>
             </nuxt-link>
         </div>
     </Table>

--- a/frontend/components/AuctionsTable.vue
+++ b/frontend/components/AuctionsTable.vue
@@ -27,7 +27,7 @@
                 v-if="record.isActive && record.marketUnitPriceToUnitPriceRatio && !record.isFinished"
                 :value="marketUnitPriceToUnitPriceRatio"
             />
-            <span v-else class="opacity-50">Unknown</span>
+            <span v-else class="opacity-50">Not tradable</span>
         </div>
         <div slot="endDate" slot-scope="endDate, record" class="text-center">
             <span v-if="record.isFinished" class="opacity-50"> Finished </span>

--- a/frontend/components/MainFlow.vue
+++ b/frontend/components/MainFlow.vue
@@ -29,6 +29,7 @@
                         :is-auctions-loading="isAuctionsLoading"
                         @restart="$emit('restart', $event)"
                         @swap="step = 2"
+                        @connect="$emit('connect')"
                     />
                 </div>
             </template>


### PR DESCRIPTION
closes #28 

> When the auction is active/not finished, but not tradable, change `Market Difference` text from `Unknown` to `Not tradable`
<img width="160" alt="image" src="https://user-images.githubusercontent.com/47861849/152805673-dc99226a-f0b4-4387-b0c4-f3c12e67a7ea.png">

> Change `See details` button text to `Participate` when the auction is active
<img width="860" alt="image" src="https://user-images.githubusercontent.com/47861849/152805787-a50e3836-f73f-4d9f-9334-4ca13f4835ab.png">

> Change `See details` button text to `Restart auction` when the auction is inactive
<img width="898" alt="image" src="https://user-images.githubusercontent.com/47861849/152805883-392bbaff-8e3b-4815-911f-ba9814c7fae1.png">

> Keep `See details` when the auction is finished
<img width="898" alt="image" src="https://user-images.githubusercontent.com/47861849/152806037-9ffa5334-f77f-4863-a772-4c47770d6c5b.png">

> On the auction page: replace `Auction Price Total` with `Unknown` when the auction is inactive
>   - Add a tooltip(like in the screenshots below) here that says something like "Since the auction is not active, there is no total Auction Price for this auction."
<img width="600" alt="image" src="https://user-images.githubusercontent.com/47861849/152806493-833872f9-e68d-4423-9d82-0b3af5d20406.png">


> Add `Connect a Wallet` block with text above `Restart Auction` block in case no wallet is connected
<img width="600" alt="image" src="https://user-images.githubusercontent.com/47861849/152806240-d5b61ea9-f336-44a0-a312-3a6111fbf20f.png">

Only showing while no wallet is connected & auction needs to be restarted.
