### PR TITLE
Fix AnimatedNumber formatting for BigNumber zero

### DIFF
--- a/frontend/components/utils/AnimatedNumber.vue
+++ b/frontend/components/utils/AnimatedNumber.vue
@@ -42,7 +42,7 @@ export default Vue.extend({
             return true;
         },
         dynamicDecimalPlaces(): number {
-            if (!this.isValidNumber || this.value === 0) {
+            if (!this.isValidNumber || this.isZero) {
                 return this.decimalPlaces;
             }
             if (Math.abs(Number(this.value)) > 1) {
@@ -60,8 +60,17 @@ export default Vue.extend({
         smallestVisibleNumber(): BigNumber {
             return new BigNumber(1).shiftedBy(-DECIMAL_PLACES_MAX);
         },
-        isValueSmallButNotZero(): boolean {
+        isZero() {
             if (this.value === 0) {
+                return true;
+            }
+            if (BigNumber.isBigNumber(this.value) && this.value.isEqualTo(0)) {
+                return true;
+            }
+            return false;
+        },
+        isValueSmallButNotZero(): boolean {
+            if (this.isZero) {
                 return false;
             }
             return new BigNumber(this.value).abs().isLessThan(this.smallestVisibleNumber);

--- a/frontend/components/utils/FormatCurrency.stories.js
+++ b/frontend/components/utils/FormatCurrency.stories.js
@@ -8,53 +8,72 @@ const common = {
 };
 
 storiesOf('Utils/FormatCurrency', module)
-    .add('Default', () => ({
+    .add('Empty / No value', () => ({
+        ...common,
+        template: '<FormatCurrency currency="dai" />',
+    }))
+    .add('Number', () => ({
         ...common,
         data: () => ({ amount: Number(faker.finance.amount()) }),
         template: '<FormatCurrency :value="amount" currency="dai" />',
     }))
-    .add('Big Number', () => ({
+    .add('BigNumber', () => ({
         ...common,
         data: () => ({ amount: new BigNumber(faker.finance.amount()) }),
         template: '<FormatCurrency :value="amount" currency="dai" />',
     }))
-    .add('Big Number NaN', () => ({
+    .add('Number NaN', () => ({
+        ...common,
+        data: () => ({ amount: NaN }),
+        template: '<FormatCurrency :value="amount" currency="dai" />',
+    }))
+    .add('BigNumber NaN', () => ({
         ...common,
         data: () => ({ amount: new BigNumber('NaN') }),
         template: '<FormatCurrency :value="amount" currency="dai" />',
     }))
-    .add('With Zero', () => ({
+    .add('Number 0', () => ({
         ...common,
         template: '<FormatCurrency :value="0" currency="dai" />',
     }))
-    .add('No value', () => ({
+    .add('BigNumber 0', () => ({
         ...common,
-        template: '<FormatCurrency currency="dai" />',
+        data: () => ({ amount: new BigNumber(0.0) }),
+        template: '<FormatCurrency :value="amount" currency="dai" />',
     }))
     .add('Number 0.000454786546', () => ({
         ...common,
         template: '<FormatCurrency :value="0.000454786546" currency="dai" />',
     }))
+    .add('BigNumber 0.000454786546', () => ({
+        ...common,
+        data: () => ({ amount: new BigNumber(0.000454786546) }),
+        template: '<FormatCurrency :value="amount" currency="dai" />',
+    }))
     .add('Number 0.0000000000001', () => ({
         ...common,
         template: '<FormatCurrency :value="0.0000000000001" currency="dai" />',
     }))
-    .add('Negative Number -10.0', () => ({
-        ...common,
-        template: '<FormatCurrency :value="-10.0" currency="dai" />',
-    }))
-    .add('Big Number 0.0004547', () => ({
-        ...common,
-        data: () => ({ amount: new BigNumber(0.0004547) }),
-        template: '<FormatCurrency :value="amount" currency="dai" />',
-    }))
-    .add('Big Number 0.0000000000001', () => ({
+    .add('BigNumber 0.0000000000001', () => ({
         ...common,
         data: () => ({ amount: new BigNumber(0.0000000000001) }),
         template: '<FormatCurrency :value="amount" currency="dai" />',
     }))
-    .add('Negative Big Number -0.0000000000001', () => ({
+    .add('Number -0.0000000000001', () => ({
+        ...common,
+        template: '<FormatCurrency :value="-0.0000000000001" currency="dai" />',
+    }))
+    .add('BigNumber -0.0000000000001', () => ({
         ...common,
         data: () => ({ amount: new BigNumber(-0.0000000000001) }),
+        template: '<FormatCurrency :value="amount" currency="dai" />',
+    }))
+    .add('Number -10', () => ({
+        ...common,
+        template: '<FormatCurrency :value="-10" currency="dai" />',
+    }))
+    .add('BigNumber -10', () => ({
+        ...common,
+        data: () => ({ amount: new BigNumber(-10) }),
         template: '<FormatCurrency :value="amount" currency="dai" />',
     }));


### PR DESCRIPTION
This PR fixes a problem spotted in https://github.com/sidestream-tech/unified-auctions-ui/pull/90#issuecomment-1036112203: when provided with `0`, we displayed `under 0.00001`. 
Now we display exactly `0.00`.