### PR TITLE
Allowance amount logic

### DIFF
--- a/core/src/authorizations.ts
+++ b/core/src/authorizations.ts
@@ -1,7 +1,9 @@
 import type { Notifier } from './types';
+import memoizee from 'memoizee';
 import getContract, { getContractAddressByName, getClipperNameByCollateralType } from './contracts';
 import executeTransaction from './execute';
-import memoizee from 'memoizee';
+import BigNumber from './bignumber';
+import { DAI_NUMBER_OF_DIGITS, MAX } from './constants/UNITS';
 
 const _authorizeWallet = async function (network: string, revoke: boolean, notifier?: Notifier): Promise<string> {
     const joinDaiAddress = await getContractAddressByName(network, 'MCD_JOIN_DAI');
@@ -63,3 +65,20 @@ export const getCollateralAuthorizationStatus = memoizee(_getCollateralAuthoriza
     promise: true,
     length: 3,
 });
+
+export const setAllowanceAmount = async function (
+    network: string,
+    amount?: BigNumber | string,
+    notifier?: Notifier
+): Promise<string> {
+    const joinDaiAddress = await getContractAddressByName(network, 'MCD_JOIN_DAI');
+    const amountRaw = amount ? new BigNumber(amount).shiftedBy(DAI_NUMBER_OF_DIGITS).toFixed(0) : MAX;
+    return await executeTransaction(network, 'MCD_DAI', 'approve', [joinDaiAddress, amountRaw], notifier);
+};
+
+export const fetchAllowanceAmount = async function (network: string, walletAddress: string): Promise<BigNumber> {
+    const joinDaiAddress = await getContractAddressByName(network, 'MCD_JOIN_DAI');
+    const DAIcontract = await getContract(network, 'MCD_DAI');
+    const allowanceRaw = await DAIcontract.allowance(walletAddress, joinDaiAddress);
+    return new BigNumber(allowanceRaw._hex).shiftedBy(-DAI_NUMBER_OF_DIGITS);
+};

--- a/core/src/authorizations.ts
+++ b/core/src/authorizations.ts
@@ -72,7 +72,7 @@ export const setAllowanceAmount = async function (
     notifier?: Notifier
 ): Promise<string> {
     const joinDaiAddress = await getContractAddressByName(network, 'MCD_JOIN_DAI');
-    const amountRaw = amount ? new BigNumber(amount).shiftedBy(DAI_NUMBER_OF_DIGITS).toFixed(0) : MAX;
+    const amountRaw = amount ? new BigNumber(amount).shiftedBy(DAI_NUMBER_OF_DIGITS).toFixed(0) : MAX.toFixed(0);
     return await executeTransaction(network, 'MCD_DAI', 'approve', [joinDaiAddress, amountRaw], notifier);
 };
 

--- a/core/src/constants/UNITS.ts
+++ b/core/src/constants/UNITS.ts
@@ -7,6 +7,7 @@ import BigNumber from 'bignumber.js';
 export const WAD = new BigNumber('1e18');
 export const RAD = new BigNumber('1e45');
 export const RAY = new BigNumber('1e27');
+export const MAX = new BigNumber('0xffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffffff');
 export const WAD_NUMBER_OF_DIGITS = 18;
 export const RAD_NUMBER_OF_DIGITS = 45;
 export const RAY_NUMBER_OF_DIGITS = 27;

--- a/frontend/store/authorizations.ts
+++ b/frontend/store/authorizations.ts
@@ -192,22 +192,18 @@ export const actions = {
             commit('setIsCollateralAuthorizationLoading', false);
         }
     },
-    async setAllowanceAmount(
-        { commit, rootGetters }: ActionContext<State, State> // amount?: BigNumber | string
-    ) {
+    async setAllowanceAmount({ commit, rootGetters }: ActionContext<State, State>, amount?: BigNumber | string) {
         commit('setIsAllowanceAmountLoading', true);
         const network = rootGetters['network/getMakerNetwork'];
         try {
-            await setAllowanceAmount(network, undefined, notifier);
+            await setAllowanceAmount(network, amount, notifier);
         } catch (error) {
             console.error(`Setting allowance amount error: ${error.message}`);
         } finally {
             commit('setIsAllowanceAmountLoading', false);
         }
     },
-    async fetchAllowanceAmount(
-        { commit, dispatch, rootGetters }: ActionContext<State, State> // amount?: BigNumber | string
-    ) {
+    async fetchAllowanceAmount({ commit, dispatch, rootGetters }: ActionContext<State, State>) {
         commit('setIsAllowanceAmountLoading', true);
         const network = rootGetters['network/getMakerNetwork'];
         const walletAddress = rootGetters['wallet/getAddress'];

--- a/frontend/store/authorizations.ts
+++ b/frontend/store/authorizations.ts
@@ -1,10 +1,14 @@
 import { ActionContext } from 'vuex';
+import BigNumber from 'bignumber.js';
 import {
     getWalletAuthorizationStatus,
     authorizeWallet,
     getCollateralAuthorizationStatus,
     authorizeCollateral,
+    setAllowanceAmount,
+    fetchAllowanceAmount,
 } from 'auctions-core/src/authorizations';
+import { setDate } from 'date-fns';
 import notifier from '~/lib/notifier';
 
 const AUTHORIZATION_STATUS_RETRY_DELAY = 1000;
@@ -14,6 +18,8 @@ interface State {
     isWalletAuthorizationDone: boolean;
     isCollateralAuthorizationLoading: boolean;
     collateralAuthorizations: string[];
+    isAllowanceAmountLoading: boolean;
+    allowanceAmount?: BigNumber;
 }
 
 const getInitialState = (): State => ({
@@ -21,6 +27,8 @@ const getInitialState = (): State => ({
     isWalletAuthorizationDone: false,
     isCollateralAuthorizationLoading: false,
     collateralAuthorizations: [],
+    isAllowanceAmountLoading: false,
+    allowanceAmount: undefined,
 });
 
 export const state = () => getInitialState();
@@ -35,6 +43,9 @@ export const getters = {
     collateralAuthorizations(state: State) {
         return state.collateralAuthorizations;
     },
+    allowanceAmount(state: State) {
+        return state.allowanceAmount ?? new BigNumber(0);
+    },
 };
 
 export const mutations = {
@@ -46,6 +57,12 @@ export const mutations = {
     },
     setIsCollateralAuthorizationLoading(state: State, isLoading: boolean) {
         state.isCollateralAuthorizationLoading = isLoading;
+    },
+    setIsAllowanceAmountLoading(state: State, isAllowanceAmountLoading: boolean) {
+        state.isAllowanceAmountLoading = isAllowanceAmountLoading;
+    },
+    setAllowanceAmount(state: State, allowanceAmount: BigNumber) {
+        state.allowanceAmount = allowanceAmount;
     },
     addCollateralAuthorization(state: State, collateralType: string) {
         if (!state.collateralAuthorizations.includes(collateralType)) {
@@ -173,6 +190,35 @@ export const actions = {
             console.error(`Collateral authorization error: ${error.message}`);
         } finally {
             commit('setIsCollateralAuthorizationLoading', false);
+        }
+    },
+    async setAllowanceAmount(
+        { commit, rootGetters }: ActionContext<State, State> // amount?: BigNumber | string
+    ) {
+        commit('setIsAllowanceAmountLoading', true);
+        const network = rootGetters['network/getMakerNetwork'];
+        try {
+            await setAllowanceAmount(network, undefined, notifier);
+        } catch (error) {
+            console.error(`Setting allowance amount error: ${error.message}`);
+        } finally {
+            commit('setIsAllowanceAmountLoading', false);
+        }
+    },
+    async fetchAllowanceAmount(
+        { commit, dispatch, rootGetters }: ActionContext<State, State> // amount?: BigNumber | string
+    ) {
+        commit('setIsAllowanceAmountLoading', true);
+        const network = rootGetters['network/getMakerNetwork'];
+        const walletAddress = rootGetters['wallet/getAddress'];
+        try {
+            const allowanceAmount = await fetchAllowanceAmount(network, walletAddress);
+            commit('setAllowanceAmount', allowanceAmount);
+        } catch (error) {
+            console.error(`Fetching allowance amount error: ${error.message}`);
+            setTimeout(() => dispatch('fetchAllowanceAmount'), AUTHORIZATION_STATUS_RETRY_DELAY);
+        } finally {
+            commit('setIsAllowanceAmountLoading', false);
         }
     },
 };

--- a/frontend/store/authorizations.ts
+++ b/frontend/store/authorizations.ts
@@ -8,7 +8,6 @@ import {
     setAllowanceAmount,
     fetchAllowanceAmount,
 } from 'auctions-core/src/authorizations';
-import { setDate } from 'date-fns';
 import notifier from '~/lib/notifier';
 
 const AUTHORIZATION_STATUS_RETRY_DELAY = 1000;


### PR DESCRIPTION
Closes https://github.com/sidestream-tech/unified-auctions-ui/issues/123

Functional testing can be done by executing in the js console:

1. To fetch amount that contract can withdraw from the user wallet:
    ```js
    await $nuxt.$store.dispatch('authorizations/fetchAllowanceAmount'); $nuxt.$store.getters['authorizations/allowanceAmount'].toFixed()
    ```

2. To set limited allowance amount
    ```js
    await $nuxt.$store.dispatch('authorizations/setAllowanceAmount', '100');
    ```
    - then rerun `1` to validate new allowance

3. Can be checked checked together with deposit logic (implemented in https://github.com/sidestream-tech/unified-auctions-ui/pull/143)
    ```js
    $nuxt.$store.dispatch('wallet/depositToVAT', '90')
    ```
    - then rerun `1` to validate that allowance decreased by 90

4. To set "unlimited" amount
    ```js
    await $nuxt.$store.dispatch('authorizations/setAllowanceAmount'); 
    ```
    - then rerun `1` to validate new allowance

5. To remove allowance
    ```js
    await $nuxt.$store.dispatch('authorizations/setAllowanceAmount', '0'); 
    ```
