### PR TITLE
Fix auth status refetching

### DIFF
--- a/bot-twitter/src/keeper.ts
+++ b/bot-twitter/src/keeper.ts
@@ -114,6 +114,7 @@ const checkAndParticipateIfPossible = async function (auction: AuctionInitialInf
         );
         const collateralTransactionHash = await authorizeCollateral(
             ETHEREUM_NETWORK,
+            walletAddress,
             auctionTransaction.collateralType,
             false
         );

--- a/bot-twitter/src/keeper.ts
+++ b/bot-twitter/src/keeper.ts
@@ -94,7 +94,7 @@ const checkAndParticipateIfPossible = async function (auction: AuctionInitialInf
     // try to authorize the wallet then return
     if (!isWalletAuth) {
         console.info(`keeper: wallet "${walletAddress}" has not been authorized yet. Attempting authorization now...`);
-        const transactionHash = await authorizeWallet(ETHEREUM_NETWORK, false);
+        const transactionHash = await authorizeWallet(ETHEREUM_NETWORK, walletAddress, false);
         console.info(`keeper: wallet "${walletAddress}" successfully authorized via "${transactionHash}" transaction`);
         await checkAndParticipateIfPossible(auction);
         return;

--- a/core/src/authorizations.ts
+++ b/core/src/authorizations.ts
@@ -5,7 +5,13 @@ import executeTransaction from './execute';
 import BigNumber from './bignumber';
 import { DAI_NUMBER_OF_DIGITS, MAX } from './constants/UNITS';
 
-const _authorizeWallet = async function (network: string, revoke: boolean, notifier?: Notifier): Promise<string> {
+const _authorizeWallet = async function (
+    network: string,
+    walletAddress: string,
+    revoke: boolean,
+    notifier?: Notifier
+): Promise<string> {
+    walletAddress; // so the memoizee cache is invalidated if another address is used
     const joinDaiAddress = await getContractAddressByName(network, 'MCD_JOIN_DAI');
     const contractMethod = revoke ? 'nope' : 'hope';
     const transaction = await executeTransaction(network, 'MCD_VAT', contractMethod, [joinDaiAddress], notifier);
@@ -15,15 +21,17 @@ const _authorizeWallet = async function (network: string, revoke: boolean, notif
 
 export const authorizeWallet = memoizee(_authorizeWallet, {
     promise: true,
-    length: 2,
+    length: 3,
 });
 
 const _authorizeCollateral = async function (
     network: string,
+    walletAddress: string,
     collateralType: string,
     revoke: boolean,
     notifier?: Notifier
 ): Promise<string> {
+    walletAddress; // so the memoizee cache is invalidated if another address is used
     const contractName = getClipperNameByCollateralType(collateralType);
     const clipperAddress = await getContractAddressByName(network, contractName);
     const contractMethod = revoke ? 'nope' : 'hope';
@@ -34,7 +42,7 @@ const _authorizeCollateral = async function (
 
 export const authorizeCollateral = memoizee(_authorizeCollateral, {
     promise: true,
-    length: 3,
+    length: 4,
 });
 
 const _getWalletAuthorizationStatus = async function (network: string, walletAddress: string): Promise<boolean> {
@@ -68,9 +76,11 @@ export const getCollateralAuthorizationStatus = memoizee(_getCollateralAuthoriza
 
 export const setAllowanceAmount = async function (
     network: string,
+    walletAddress: string,
     amount?: BigNumber | string,
     notifier?: Notifier
 ): Promise<string> {
+    walletAddress; // so the memoizee cache is invalidated if another address is used
     const joinDaiAddress = await getContractAddressByName(network, 'MCD_JOIN_DAI');
     const amountRaw = amount ? new BigNumber(amount).shiftedBy(DAI_NUMBER_OF_DIGITS).toFixed(0) : MAX.toFixed(0);
     return await executeTransaction(network, 'MCD_DAI', 'approve', [joinDaiAddress, amountRaw], notifier);

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -97,6 +97,15 @@ export default Vue.extend({
                 this.fetchCollateralAuthorizationStatus(this.selectedAuction.collateralType);
             },
         },
+        walletAddress(newWalletAddress) {
+            if (!newWalletAddress) {
+                return;
+            }
+            this.fetchWalletAuthorizationStatus();
+            if (this.selectedAuction) {
+                this.fetchCollateralAuthorizationStatus(this.selectedAuction.collateralType);
+            }
+        },
     },
     methods: {
         ...mapActions('authorizations', [

--- a/frontend/store/authorizations.ts
+++ b/frontend/store/authorizations.ts
@@ -116,8 +116,9 @@ export const actions = {
     async authorizeWallet({ commit, dispatch, rootGetters }: ActionContext<State, State>) {
         commit('setIsWalletAuthorizationLoading', true);
         const network = rootGetters['network/getMakerNetwork'];
+        const walletAddress = rootGetters['wallet/getAddress'];
         try {
-            await authorizeWallet(network, false, notifier);
+            await authorizeWallet(network, walletAddress, false, notifier);
             await dispatch('fetchWalletAuthorizationStatus');
         } catch (error) {
             console.error(`Wallet authorization error: ${error.message}`);
@@ -128,8 +129,9 @@ export const actions = {
     async deauthorizeWallet({ commit, dispatch, rootGetters }: ActionContext<State, State>) {
         commit('setIsWalletAuthorizationLoading', true);
         const network = rootGetters['network/getMakerNetwork'];
+        const walletAddress = rootGetters['wallet/getAddress'];
         try {
-            await authorizeWallet(network, true, notifier);
+            await authorizeWallet(network, walletAddress, true, notifier);
             await dispatch('fetchWalletAuthorizationStatus');
         } catch (error) {
             console.error(`Wallet authorization error: ${error.message}`);
@@ -167,8 +169,9 @@ export const actions = {
     async authorizeCollateral({ commit, dispatch, rootGetters }: ActionContext<State, State>, collateralType: string) {
         commit('setIsCollateralAuthorizationLoading', true);
         const network = rootGetters['network/getMakerNetwork'];
+        const walletAddress = rootGetters['wallet/getAddress'];
         try {
-            await authorizeCollateral(network, collateralType, false, notifier);
+            await authorizeCollateral(network, walletAddress, collateralType, false, notifier);
             await dispatch('fetchCollateralAuthorizationStatus', collateralType);
         } catch (error) {
             console.error(`Collateral authorization error: ${error.message}`);
@@ -182,8 +185,9 @@ export const actions = {
     ) {
         commit('setIsCollateralAuthorizationLoading', true);
         const network = rootGetters['network/getMakerNetwork'];
+        const walletAddress = rootGetters['wallet/getAddress'];
         try {
-            await authorizeCollateral(network, collateralType, true, notifier);
+            await authorizeCollateral(network, walletAddress, collateralType, true, notifier);
             await dispatch('fetchCollateralAuthorizationStatus', collateralType);
         } catch (error) {
             console.error(`Collateral authorization error: ${error.message}`);
@@ -197,8 +201,9 @@ export const actions = {
     ) {
         commit('setIsAllowanceAmountLoading', true);
         const network = rootGetters['network/getMakerNetwork'];
+        const walletAddress = rootGetters['wallet/getAddress'];
         try {
-            await setAllowanceAmount(network, amount, notifier);
+            await setAllowanceAmount(network, walletAddress, amount, notifier);
             await dispatch('fetchAllowanceAmount');
         } catch (error) {
             console.error(`Setting allowance amount error: ${error.message}`);

--- a/frontend/store/authorizations.ts
+++ b/frontend/store/authorizations.ts
@@ -10,6 +10,7 @@ import {
 } from 'auctions-core/src/authorizations';
 import notifier from '~/lib/notifier';
 
+const delay = (delay: number) => new Promise(resolve => setTimeout(resolve, delay));
 const AUTHORIZATION_STATUS_RETRY_DELAY = 1000;
 
 interface State {
@@ -106,7 +107,8 @@ export const actions = {
         } catch (error) {
             commit('setIsWalletAuthorizationDone', false);
             console.error(`Wallet authorization status error: ${error.message}`);
-            setTimeout(() => dispatch('fetchWalletAuthorizationStatus'), AUTHORIZATION_STATUS_RETRY_DELAY);
+            await delay(AUTHORIZATION_STATUS_RETRY_DELAY);
+            await dispatch('fetchWalletAuthorizationStatus');
         } finally {
             commit('setIsWalletAuthorizationLoading', false);
         }
@@ -116,7 +118,7 @@ export const actions = {
         const network = rootGetters['network/getMakerNetwork'];
         try {
             await authorizeWallet(network, false, notifier);
-            dispatch('fetchWalletAuthorizationStatus');
+            await dispatch('fetchWalletAuthorizationStatus');
         } catch (error) {
             console.error(`Wallet authorization error: ${error.message}`);
         } finally {
@@ -128,7 +130,7 @@ export const actions = {
         const network = rootGetters['network/getMakerNetwork'];
         try {
             await authorizeWallet(network, true, notifier);
-            dispatch('fetchWalletAuthorizationStatus');
+            await dispatch('fetchWalletAuthorizationStatus');
         } catch (error) {
             console.error(`Wallet authorization error: ${error.message}`);
         } finally {
@@ -156,10 +158,8 @@ export const actions = {
             return isAuthorized;
         } catch (error) {
             console.error(`Collateral authorization status error: ${error.message}`);
-            setTimeout(
-                () => dispatch('fetchCollateralAuthorizationStatus', collateralType),
-                AUTHORIZATION_STATUS_RETRY_DELAY
-            );
+            await delay(AUTHORIZATION_STATUS_RETRY_DELAY);
+            await dispatch('fetchCollateralAuthorizationStatus', collateralType);
         } finally {
             commit('setIsCollateralAuthorizationLoading', false);
         }
@@ -169,7 +169,7 @@ export const actions = {
         const network = rootGetters['network/getMakerNetwork'];
         try {
             await authorizeCollateral(network, collateralType, false, notifier);
-            dispatch('fetchCollateralAuthorizationStatus', collateralType);
+            await dispatch('fetchCollateralAuthorizationStatus', collateralType);
         } catch (error) {
             console.error(`Collateral authorization error: ${error.message}`);
         } finally {
@@ -184,18 +184,22 @@ export const actions = {
         const network = rootGetters['network/getMakerNetwork'];
         try {
             await authorizeCollateral(network, collateralType, true, notifier);
-            dispatch('fetchCollateralAuthorizationStatus', collateralType);
+            await dispatch('fetchCollateralAuthorizationStatus', collateralType);
         } catch (error) {
             console.error(`Collateral authorization error: ${error.message}`);
         } finally {
             commit('setIsCollateralAuthorizationLoading', false);
         }
     },
-    async setAllowanceAmount({ commit, rootGetters }: ActionContext<State, State>, amount?: BigNumber | string) {
+    async setAllowanceAmount(
+        { commit, dispatch, rootGetters }: ActionContext<State, State>,
+        amount?: BigNumber | string
+    ) {
         commit('setIsAllowanceAmountLoading', true);
         const network = rootGetters['network/getMakerNetwork'];
         try {
             await setAllowanceAmount(network, amount, notifier);
+            await dispatch('fetchAllowanceAmount');
         } catch (error) {
             console.error(`Setting allowance amount error: ${error.message}`);
         } finally {
@@ -211,7 +215,8 @@ export const actions = {
             commit('setAllowanceAmount', allowanceAmount);
         } catch (error) {
             console.error(`Fetching allowance amount error: ${error.message}`);
-            setTimeout(() => dispatch('fetchAllowanceAmount'), AUTHORIZATION_STATUS_RETRY_DELAY);
+            await delay(AUTHORIZATION_STATUS_RETRY_DELAY);
+            await dispatch('fetchAllowanceAmount');
         } finally {
             commit('setIsAllowanceAmountLoading', false);
         }


### PR DESCRIPTION
This PR fixes few auth-related bugs that I've noticed:

1. After the auth was executed, the auth button becomes active again for a second before turning into the authorized state:
    
    https://user-images.githubusercontent.com/3393626/158641177-c3abc6cd-5649-4546-8c8d-3665d550de5c.mov

2. If the user changes the `walletAddress` within metamask, we did not refetch auth states (until another auction is selected), it's solved now

3. If the user executed an auth step, changed the `walletAddress` within metamask, and tried to execute the same auth step with the new `walletAddress` was prevented due to caching logic, it's solved now

