### PR TITLE
Wallet with panels

### DIFF
--- a/frontend/assets/styles/ant-design.less
+++ b/frontend/assets/styles/ant-design.less
@@ -3,6 +3,7 @@
 @primary-color: #1aab9b;
 @modal-body-padding: 0px;
 @dropdown-selected-color: @text-color;
+@border-width-base: 2px;
 
 .anticon {
     vertical-align: 0.125em !important;

--- a/frontend/components/MainFlow.vue
+++ b/frontend/components/MainFlow.vue
@@ -64,7 +64,6 @@
                     :is-depositing-or-withdrawing="isDepositingOrWithdrawing"
                     :is-executing="isExecuting"
                     :is-wallet-authorized="isWalletAuthorized"
-                    :is-dai-access-granted="isDaiAccessGranted"
                     :is-explanations-shown="isExplanationsShown"
                     :authorised-collaterals="authorisedCollaterals"
                     :wallet-address="walletAddress"

--- a/frontend/components/MainFlow.vue
+++ b/frontend/components/MainFlow.vue
@@ -44,7 +44,7 @@
                     :auction-transaction="selectedAuction"
                     :is-connecting="isConnecting"
                     :is-authorizing="isAuthorizing"
-                    :is-wallet-authorised="isWalletAuthorised"
+                    :is-wallet-authorized="isWalletAuthorized"
                     :authorised-collaterals="authorisedCollaterals"
                     :is-executing="isExecuting"
                     :wallet-address="walletAddress"
@@ -64,7 +64,7 @@
                     :is-depositing="isDepositingDai"
                     :is-authorizing="isAuthorizing"
                     :is-executing="isExecuting"
-                    :is-wallet-authorised="isWalletAuthorised"
+                    :is-wallet-authorized="isWalletAuthorized"
                     :is-dai-access-granted="isDaiAccessGranted"
                     :is-explanations-shown="isExplanationsShown"
                     :authorised-collaterals="authorisedCollaterals"
@@ -144,7 +144,7 @@ export default Vue.extend({
             type: Boolean,
             default: false,
         },
-        isWalletAuthorised: {
+        isWalletAuthorized: {
             type: Boolean,
             default: false,
         },

--- a/frontend/components/common/BaseButton.vue
+++ b/frontend/components/common/BaseButton.vue
@@ -1,8 +1,8 @@
 <template>
     <Button
         :disabled="disabled || isLoading"
-        :class="buttonStyles"
-        class="overflow-hidden"
+        :class="buttonClass"
+        class="Button"
         :type="type"
         :html-type="htmlType"
         @click="$emit('click')"
@@ -43,35 +43,43 @@ export default Vue.extend({
         },
     },
     computed: {
-        buttonStyles() {
+        buttonClass() {
             if (this.type === 'primary') {
-                return 'Button-Primary';
+                return 'Primary';
             }
             if (this.type === 'link') {
-                return 'Button-Link';
+                return 'Link';
             }
-            return '';
+            return 'Default';
         },
     },
 });
 </script>
 
 <style>
-.Button-Primary,
-.dark .Button-Primary {
+.Button {
+    @apply overflow-hidden;
+}
+
+.Button.Default:enabled {
+    @apply border-primary text-primary hover:text-white hover:bg-primary-light hover:border-primary-light;
+}
+
+.Primary,
+.dark .Primary {
     @apply text-white bg-primary border-primary focus:bg-primary-light focus:border-primary-light hover:bg-primary-light hover:border-primary-light;
 }
 
-.Button-Link,
-.dark .Button-Link {
-    @apply inline-flex items-center p-0 h-auto;
+.Link,
+.dark .Link {
+    @apply inline-flex items-center p-0 h-auto leading-4;
 }
 
-.Button-Link span {
+.Link span {
     @apply text-primary underline overflow-auto transition-colors;
 }
 
-.Button-Link:hover span {
+.Link:hover span {
     @apply text-primary-light no-underline;
 }
 </style>

--- a/frontend/components/common/BaseButton.vue
+++ b/frontend/components/common/BaseButton.vue
@@ -65,8 +65,8 @@ export default Vue.extend({
     @apply border-primary text-primary hover:text-white hover:bg-primary-light hover:border-primary-light;
 }
 
-.Primary,
-.dark .Primary {
+.Primary:enabled,
+.dark .Primary:enabled {
     @apply text-white bg-primary border-primary focus:bg-primary-light focus:border-primary-light hover:bg-primary-light hover:border-primary-light;
 }
 

--- a/frontend/components/common/BaseButton.vue
+++ b/frontend/components/common/BaseButton.vue
@@ -56,7 +56,7 @@ export default Vue.extend({
 });
 </script>
 
-<style>
+<style scoped>
 .Button {
     @apply overflow-hidden;
 }

--- a/frontend/components/common/BasePanel.stories.js
+++ b/frontend/components/common/BasePanel.stories.js
@@ -16,38 +16,43 @@ storiesOf('common/BasePanel', module)
     .add('Stack of panels', () => ({
         ...common,
         template: `<div>
-            <BasePanel v-bind="$data" currentState="incorrect"> Error content </BasePanel>
-            <BasePanel v-bind="$data" currentState="notice"> Notice content </BasePanel>
-            <BasePanel v-bind="$data" currentState="correct"> Correct content </BasePanel>
-            <BasePanel v-bind="$data" currentState="inactive"> Inactive content </BasePanel>
+            <BasePanel currentState="incorrect"><template #title>{{ incorrect }}</template>Error content</BasePanel>
+            <BasePanel currentState="notice"><template #title>{{ notice }}</template>Notice content</BasePanel>
+            <BasePanel currentState="correct"><template #title>{{ correct }}</template>Correct content</BasePanel>
+            <BasePanel currentState="inactive"><template #title>{{ inactive }}</template>Inactive content</BasePanel>
         </div>`,
     }))
     .add('Inactive', () => ({
         ...common,
-        template: '<BasePanel v-bind="$data" currentState="inactive"> Inactive content </BasePanel>',
+        template:
+            '<BasePanel currentState="inactive"><template #title>{{ inactive }}</template>Inactive content</BasePanel>',
     }))
     .add('Incorrect', () => ({
         ...common,
-        template: '<BasePanel v-bind="$data" currentState="incorrect"> Incorrect content </BasePanel>',
+        template:
+            '<BasePanel currentState="incorrect"><template #title>{{ incorrect }}</template>Incorrect content</BasePanel>',
     }))
     .add('Correct', () => ({
         ...common,
-        template: '<BasePanel v-bind="$data" currentState="correct"> Correct content </BasePanel>',
+        template:
+            '<BasePanel currentState="correct"><template #title>{{ correct }}</template>Correct content</BasePanel>',
     }))
     .add('Notice', () => ({
         ...common,
-        template: '<BasePanel v-bind="$data" currentState="notice"> Notice content </BasePanel>',
+        template:
+            '<BasePanel currentState="notice"><template #title>{{ notice }}</template>Notice content</BasePanel>',
     }))
     .add('Very long notice', () => ({
         ...common,
-        template: `<BasePanel notice="${faker.lorem.sentence(20)}" currentState="notice">
+        template: `<BasePanel currentState="notice">
+            <template #title>${faker.lorem.sentence(20)}</template>
             Content: ${faker.lorem.sentence(50)}
         </BasePanel>`,
     }))
     .add('Notice with html', () => ({
         ...common,
         template: `<BasePanel currentState="notice">
-            <template #notice>Title with <i>italic</i> text</template>
+            <template #title>Title with <i>italic</i> text</template>
             Content: ${faker.lorem.sentence(50)}
         </BasePanel>`,
     }));

--- a/frontend/components/common/BasePanel.vue
+++ b/frontend/components/common/BasePanel.vue
@@ -1,14 +1,23 @@
 <template>
     <div class="BasePanel">
-        <button class="Title" :class="titleClass" @click="isExpanded = !isExpanded">
-            <div class="Icon" :class="iconClass">
-                <Icon v-if="currentState === 'inactive'" type="close" />
-                <Icon v-else-if="currentState === 'incorrect'" type="warning" theme="filled" />
-                <Icon v-else-if="currentState === 'correct'" type="check" />
-                <Icon v-else-if="currentState === 'notice'" type="warning" theme="filled" />
-            </div>
-            <slot :name="currentState">{{ $props[currentState] }}</slot>
-        </button>
+        <template v-for="state of STATES">
+            <button
+                v-if="$slots[state.name]"
+                :key="state.name"
+                class="Title"
+                type="button"
+                :class="titleClass(state.name)"
+                @click="isExpanded = !isExpanded"
+            >
+                <div class="Icon" :class="iconClass(state.name)">
+                    <Icon v-if="state.name === 'inactive'" type="close" />
+                    <Icon v-else-if="state.name === 'incorrect'" type="warning" theme="filled" />
+                    <Icon v-else-if="state.name === 'correct'" type="check" />
+                    <Icon v-else-if="state.name === 'notice'" type="warning" theme="filled" />
+                </div>
+                <slot :name="state.name">{{ $props[state.name] }}</slot>
+            </button>
+        </template>
         <div v-show="isExpanded" class="Content">
             <slot />
         </div>
@@ -51,11 +60,6 @@ export default Vue.extend({
         Icon,
     },
     props: {
-        currentState: {
-            type: String,
-            required: true,
-            validator: (value: string) => STATES.map(s => s.name).includes(value),
-        },
         ...STATES.reduce(
             (props, state) => ({
                 ...props,
@@ -69,25 +73,26 @@ export default Vue.extend({
     },
     data() {
         return {
+            STATES,
             isExpanded: false,
         };
-    },
-    computed: {
-        titleClass() {
-            return STATES.find(s => s.name === this.currentState)?.titleClass;
-        },
-        iconClass() {
-            return STATES.find(s => s.name === this.currentState)?.iconClass;
-        },
     },
     watch: {
         currentState: {
             immediate: true,
-            handler(newState: string) {
+            handler(newState: string): void {
                 this.isExpanded = STATES.filter(s => s.isExpanded)
                     .map(s => s.name)
                     .includes(newState);
             },
+        },
+    },
+    methods: {
+        titleClass(stateName: string): string | undefined {
+            return STATES.find(s => s.name === stateName)?.titleClass;
+        },
+        iconClass(stateName: string): string | undefined {
+            return STATES.find(s => s.name === stateName)?.iconClass;
         },
     },
 });
@@ -98,8 +103,17 @@ export default Vue.extend({
     @apply flex flex-col;
     @apply border-2 border-gray-300 dark:border-gray-600 dark:text-gray-200;
 }
+.BasePanel:first-child {
+    @apply rounded-t;
+}
+.BasePanel:last-child {
+    @apply rounded-b;
+}
+.BasePanel:only-child {
+    @apply rounded;
+}
 .BasePanel + .BasePanel {
-    margin-top: -2px;
+    margin-top: -1px;
 }
 .Title {
     @apply px-2 py-1 text-left;
@@ -108,6 +122,6 @@ export default Vue.extend({
     @apply inline;
 }
 .Content {
-    @apply px-2 py-1;
+    @apply px-3 py-1;
 }
 </style>

--- a/frontend/components/common/BasePanel.vue
+++ b/frontend/components/common/BasePanel.vue
@@ -113,7 +113,7 @@ export default Vue.extend({
     @apply rounded;
 }
 .BasePanel + .BasePanel {
-    margin-top: -1px;
+    margin-top: -2px;
 }
 .Title {
     @apply px-2 py-1 text-left;
@@ -122,6 +122,6 @@ export default Vue.extend({
     @apply inline;
 }
 .Content {
-    @apply px-3 py-1;
+    @apply px-3 pt-1 pb-3;
 }
 </style>

--- a/frontend/components/common/BasePanel.vue
+++ b/frontend/components/common/BasePanel.vue
@@ -9,15 +9,18 @@
             </div>
             <slot name="title" />
         </button>
-        <div v-show="isExpanded" class="Content">
-            <slot />
-        </div>
+        <CollapseTransition>
+            <div v-show="isExpanded" class="Content">
+                <slot />
+            </div>
+        </CollapseTransition>
     </div>
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import { Icon } from 'ant-design-vue';
+import CollapseTransition from '@ivanv/vue-collapse-transition';
 
 const STATES = [
     {
@@ -49,6 +52,7 @@ const STATES = [
 export default Vue.extend({
     components: {
         Icon,
+        CollapseTransition,
     },
     props: {
         currentState: {

--- a/frontend/components/common/BasePanel.vue
+++ b/frontend/components/common/BasePanel.vue
@@ -1,23 +1,14 @@
 <template>
     <div class="BasePanel">
-        <template v-for="state of STATES">
-            <button
-                v-if="$slots[state.name]"
-                :key="state.name"
-                class="Title"
-                type="button"
-                :class="titleClass(state.name)"
-                @click="isExpanded = !isExpanded"
-            >
-                <div class="Icon" :class="iconClass(state.name)">
-                    <Icon v-if="state.name === 'inactive'" type="close" />
-                    <Icon v-else-if="state.name === 'incorrect'" type="warning" theme="filled" />
-                    <Icon v-else-if="state.name === 'correct'" type="check" />
-                    <Icon v-else-if="state.name === 'notice'" type="warning" theme="filled" />
-                </div>
-                <slot :name="state.name">{{ $props[state.name] }}</slot>
-            </button>
-        </template>
+        <button class="Title" type="button" :class="titleClass" @click="isExpanded = !isExpanded">
+            <div class="Icon" :class="iconClass">
+                <Icon v-if="currentState === 'inactive'" type="close" />
+                <Icon v-else-if="currentState === 'incorrect'" type="warning" theme="filled" />
+                <Icon v-else-if="currentState === 'correct'" type="check" />
+                <Icon v-else-if="currentState === 'notice'" type="warning" theme="filled" />
+            </div>
+            <slot name="title" />
+        </button>
         <div v-show="isExpanded" class="Content">
             <slot />
         </div>
@@ -60,22 +51,24 @@ export default Vue.extend({
         Icon,
     },
     props: {
-        ...STATES.reduce(
-            (props, state) => ({
-                ...props,
-                [state.name]: {
-                    type: String,
-                    default: '',
-                },
-            }),
-            {}
-        ),
+        currentState: {
+            type: String,
+            required: true,
+            validator: (value: string) => STATES.map(s => s.name).includes(value),
+        },
     },
     data() {
         return {
-            STATES,
             isExpanded: false,
         };
+    },
+    computed: {
+        titleClass(): string | undefined {
+            return STATES.find(s => s.name === this.currentState)?.titleClass;
+        },
+        iconClass(): string | undefined {
+            return STATES.find(s => s.name === this.currentState)?.iconClass;
+        },
     },
     watch: {
         currentState: {
@@ -85,14 +78,6 @@ export default Vue.extend({
                     .map(s => s.name)
                     .includes(newState);
             },
-        },
-    },
-    methods: {
-        titleClass(stateName: string): string | undefined {
-            return STATES.find(s => s.name === stateName)?.titleClass;
-        },
-        iconClass(stateName: string): string | undefined {
-            return STATES.find(s => s.name === stateName)?.iconClass;
         },
     },
 });

--- a/frontend/components/common/BaseValueInput.vue
+++ b/frontend/components/common/BaseValueInput.vue
@@ -1,0 +1,146 @@
+<template>
+    <div class="BaseValueInput">
+        <Tooltip :visible="!!errorMessage" placement="topLeft" :title="errorMessage">
+            <Input
+                v-model="inputText"
+                class="Input"
+                :class="{ Error: !!errorMessage }"
+                :disabled="disabled"
+                @focus="hideMaxValue"
+                @blur="showMaxValueIfEmpty"
+            />
+            <div v-if="!inputValue" class="Overlay MaxValue">
+                <format-currency v-if="maxValue" :value="maxValue" :class="{ 'opacity-50': disabled }" />
+            </div>
+            <span class="Overlay right-1" :class="{ 'opacity-50': disabled }">DAI</span>
+        </Tooltip>
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import BigNumber from 'bignumber.js';
+import { Input, Tooltip } from 'ant-design-vue';
+import FormatCurrency from '~/components/utils/FormatCurrency.vue';
+
+export default Vue.extend({
+    components: { FormatCurrency, Tooltip, Input },
+    props: {
+        inputValue: {
+            type: Object as Vue.PropType<BigNumber> | undefined,
+            default: undefined,
+        },
+        minValue: {
+            type: Object as Vue.PropType<BigNumber>,
+            default: undefined,
+        },
+        maxValue: {
+            type: Object as Vue.PropType<BigNumber>,
+            default: undefined,
+        },
+        validator: {
+            type: Function as Vue.PropType<function>,
+            default: () => {},
+        },
+        disabled: {
+            type: Boolean,
+            default: false,
+        },
+    },
+    data() {
+        return {
+            inputText: '',
+        };
+    },
+    computed: {
+        isInputEmpty(): boolean {
+            return this.inputText.trim() === '';
+        },
+        inputTextParsed(): BigNumber | undefined {
+            if (this.isInputEmpty) {
+                return undefined;
+            }
+            return new BigNumber(this.inputText.trim());
+        },
+        errorMessage(): string {
+            try {
+                if (this.validator) {
+                    this.validator(this.inputTextParsed, this.minValue, this.maxValue);
+                }
+            } catch (error) {
+                return error.message;
+            }
+            return '';
+        },
+    },
+    watch: {
+        inputText(_newInputText: string, oldInputText: string) {
+            if (this.error) {
+                this.$emit('update:inputValue', new BigNumber(NaN));
+                return;
+            }
+            if (!this.inputTextParsed) {
+                return;
+            }
+            if (this.inputTextParsed.isNaN()) {
+                this.inputText = oldInputText || '';
+                return;
+            }
+            this.$emit('update:inputValue', this.inputTextParsed);
+        },
+        inputValue(newInputValue: BigNumber | undefined) {
+            if (!newInputValue) {
+                this.inputText = '';
+                return;
+            }
+            if (newInputValue.isEqualTo(this.minValue) && !newInputValue.isZero()) {
+                this.inputText = newInputValue.toFixed();
+            }
+        },
+    },
+    methods: {
+        hideMaxValue(): void {
+            if (!this.inputValue) {
+                this.$emit('update:inputValue', new BigNumber(NaN));
+            }
+        },
+        showMaxValueIfEmpty(): void {
+            if (this.isInputEmpty) {
+                this.$emit('update:inputValue', undefined);
+            }
+        },
+    },
+});
+</script>
+
+<style scoped>
+.BaseValueInput {
+    @apply w-full relative dark:text-gray-300;
+}
+
+.Input {
+    @apply text-right;
+
+    padding-right: 30px;
+}
+
+.Error {
+    @apply border-red-500 hover:border-red-400;
+}
+
+.Error:focus {
+    @apply border-red-400;
+
+    box-shadow: 0 0 3px rgb(239, 68, 68);
+}
+
+.Overlay {
+    @apply absolute pointer-events-none;
+
+    top: 5.5px;
+}
+
+.MaxValue {
+    right: 30px;
+}
+</style>

--- a/frontend/components/common/BaseValueInput.vue
+++ b/frontend/components/common/BaseValueInput.vue
@@ -74,11 +74,8 @@ export default Vue.extend({
     },
     watch: {
         inputText(_newInputText: string, oldInputText: string) {
-            if (this.error) {
+            if (this.errorMessage || !this.inputTextParsed) {
                 this.$emit('update:inputValue', new BigNumber(NaN));
-                return;
-            }
-            if (!this.inputTextParsed) {
                 return;
             }
             if (this.inputTextParsed.isNaN()) {

--- a/frontend/components/common/BaseValueInput.vue
+++ b/frontend/components/common/BaseValueInput.vue
@@ -9,10 +9,9 @@
                 @focus="hideMaxValue"
                 @blur="showMaxValueIfEmpty"
             />
-            <div v-if="!inputValue" class="Overlay MaxValue">
-                <format-currency v-if="maxValue" :value="maxValue" :class="{ 'opacity-50': disabled }" />
+            <div class="Overlay right-2" :class="{ 'opacity-50': disabled }">
+                <format-currency v-if="!inputValue && maxValue" :value="maxValue" />&nbsp;DAI
             </div>
-            <span class="Overlay right-1" :class="{ 'opacity-50': disabled }">DAI</span>
         </Tooltip>
     </div>
 </template>
@@ -119,9 +118,7 @@ export default Vue.extend({
 }
 
 .Input {
-    @apply text-right;
-
-    padding-right: 30px;
+    @apply text-right pr-8;
 }
 
 .Error {
@@ -135,12 +132,8 @@ export default Vue.extend({
 }
 
 .Overlay {
-    @apply absolute pointer-events-none;
+    @apply absolute pointer-events-none h-full flex items-center;
 
-    top: 5.5px;
-}
-
-.MaxValue {
-    right: 30px;
+    top: 0.5px;
 }
 </style>

--- a/frontend/components/common/Loading.vue
+++ b/frontend/components/common/Loading.vue
@@ -7,7 +7,7 @@
             :class="{
                 'bg-white dark:bg-gray-800 dark:bg-opacity-90': isLoading,
                 'bg-gray-200 dark:bg-gray-800 dark:bg-opacity-95': !isLoading && error,
-                'bg-opacity-90': isLoading || error,
+                'bg-opacity-60': isLoading || error,
             }"
         >
             <LoadingIcon v-if="isLoading" class="h-8 w-8 animate animate-spin fill-current dark:text-gray-300" />

--- a/frontend/components/layout/LandingBlock.vue
+++ b/frontend/components/layout/LandingBlock.vue
@@ -46,12 +46,15 @@ export default Vue.extend({
 }
 .ButtonBase {
     @apply rounded-full border-2;
-}
-.PrimaryButton {
-    @apply ButtonBase bg-primary-light border-primary focus:bg-primary-light hover:bg-white hover:text-primary focus:text-primary dark:bg-primary-dark dark:border-primary-dark dark:text-white dark:hover:bg-primary;
+    @apply text-gray-500 !important;
 }
 .SecondaryButton {
-    @apply ButtonBase border-gray-500 hover:text-primary focus:text-primary hover:border-primary dark:bg-gray-600 dark:border-gray-600 dark:text-white dark:hover:bg-gray-500;
+    @apply ButtonBase hover:border-primary dark:bg-gray-600 dark:border-gray-600 dark:text-white dark:hover:bg-gray-500;
+    @apply border-gray-500 hover:border-primary hover:bg-white hover:text-primary focus:text-primary !important;
+}
+.PrimaryButton {
+    @apply ButtonBase bg-primary-light border-primary focus:bg-primary-light dark:bg-primary-dark dark:border-primary-dark dark:text-white dark:hover:bg-primary;
+    @apply hover:bg-white hover:border-primary hover:text-primary focus:text-primary !important;
 }
 .LandingTitle {
     @apply text-4xl font-bold text-gray-800 dark:text-gray-100 px-4;

--- a/frontend/components/panels/AllowanceAmountCheckPanel.vue
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.vue
@@ -1,0 +1,94 @@
+<template>
+    <BasePanel class="WalletDaiCheckPanel">
+        <template #[currentStateAndTitle.name]>{{ currentStateAndTitle.title }}</template>
+        <TextBlock>
+            If you do not have DAI funds to deposit yet, there are several ways to obtain them:
+            <ul class="list-disc list-inside">
+                <li>
+                    By borrowing DAI against a collateral in the
+                    <a href="https://oasis.app/" target="_blank">oasis.app</a>
+                </li>
+                <li>
+                    By purchasing it on a decentralized exchange like
+                    <a href="https://uniswap.org/" target="_blank">uniswap.org</a> (correct DAI token address used on
+                    the “{{ networkTitle }}” network is
+                    <FormatAddress type="address" :value="tokenAddressDai" shorten />)
+                </li>
+            </ul>
+            <div class="flex justify-end my-2">
+                <BaseButton @click="$emit('refresh')">Refresh wallet balance</BaseButton>
+            </div>
+        </TextBlock>
+    </BasePanel>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import BigNumber from 'bignumber.js';
+import { getNetworkConfigByType } from 'auctions-core/src/constants/NETWORKS';
+import BaseButton from '~/components/common/BaseButton.vue';
+import BasePanel from '~/components/common/BasePanel.vue';
+import TextBlock from '~/components/common/TextBlock.vue';
+import FormatAddress from '~/components/utils/FormatAddress.vue';
+
+export default Vue.extend({
+    components: {
+        BaseButton,
+        BasePanel,
+        TextBlock,
+        FormatAddress,
+    },
+    props: {
+        walletDai: {
+            type: Object as Vue.PropType<BigNumber>,
+            default: undefined,
+        },
+        wantToDepositDai: {
+            type: Object as Vue.PropType<BigNumber>,
+            default: undefined,
+        },
+        network: {
+            type: String,
+            default: undefined,
+        },
+        tokenAddressDai: {
+            type: String,
+            default: undefined,
+        },
+    },
+    computed: {
+        currentStateAndTitle(): PanelProps {
+            if (!this.allowanceAmount) {
+                return {
+                    name: 'inactive',
+                    title: 'Please connect a wallet',
+                };
+            }
+            if (!this.wantToDepositDai) {
+                return {
+                    name: 'inactive',
+                    title: 'Please enter the value to deposit first',
+                };
+            }
+            const isTooSmall = this.wantToDepositDai?.isGreaterThan(this.walletDai || new BigNumber(0));
+            if (isTooSmall) {
+                return {
+                    name: 'incorrect',
+                    title: 'The sufficient amount of DAI is not present in the connected wallet',
+                };
+            }
+            return {
+                name: 'correct',
+                title: 'The sufficient amount of DAI is present in the connected wallet',
+            };
+        },
+        networkTitle(): string {
+            try {
+                return getNetworkConfigByType(this.network).title;
+            } catch {
+                return this.network;
+            }
+        },
+    },
+});
+</script>

--- a/frontend/components/panels/AllowanceAmountCheckPanel.vue
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.vue
@@ -109,7 +109,7 @@ export default Vue.extend({
                     title: 'Please connect a wallet',
                 };
             }
-            if (!this.desiredAmount) {
+            if (!this.desiredAmount || this.desiredAmount?.isNaN()) {
                 return {
                     name: 'inactive',
                     title: 'Please enter the desired value first',

--- a/frontend/components/panels/AllowanceAmountCheckPanel.vue
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.vue
@@ -1,8 +1,8 @@
 <template>
-    <BasePanel class="WalletDaiDepositCheckPanel">
-        <template #[currentStateAndTitle.name]>{{ currentStateAndTitle.title }}</template>
+    <BasePanel :current-state="currentStateAndTitle.name" class="WalletDaiDepositCheckPanel">
+        <template #title>{{ currentStateAndTitle.title }}</template>
         <TextBlock v-if="isExplanationsShown">
-            To bid on an auction with Dai, first funds need to be deposited to the
+            To bid on an auction with DAI, first funds need to be deposited to the
             <Explain text="VAT">
                 The
                 <a
@@ -34,7 +34,7 @@
             <BaseButton
                 class="w-full md:w-80"
                 :type="!isEnough ? 'primary' : ''"
-                :disabled="disabled"
+                :disabled="disabled || isUnlimitedAllowance"
                 :is-loading="isLoading"
                 @click="$emit('setAllowanceAmount')"
             >

--- a/frontend/components/panels/WalletAuthorizationCheckPanel.vue
+++ b/frontend/components/panels/WalletAuthorizationCheckPanel.vue
@@ -1,0 +1,103 @@
+<template>
+    <BasePanel :current-state="currentStateAndTitle.name" class="WalletAuthorizationCheckPanel">
+        <template #title>{{ currentStateAndTitle.title }}</template>
+        <TextBlock v-if="isExplanationsShown">
+            In order for some
+            <Explain text="smart contracts">
+                The particular smart contract is called DaiJoin and its technical specification can be found
+                <a href="https://github.com/makerdao/dss/blob/master/src/join.sol#L106-L142" target="_blank">here</a>
+            </Explain>
+            to modify your internal DAI
+            <Explain text="balance">
+                The core vault engine of the Maker Protocol is called VAT and manages the central accounting invariants
+                of DAI. More information on the VAT can be found
+                <a
+                    href="https://docs.makerdao.com/smart-contract-modules/core-module/vat-detailed-documentation#2-contract-details"
+                    target="_blank"
+                    >here</a
+                > </Explain
+            >. This operation should only be done once.
+        </TextBlock>
+        <div class="flex justify-end mt-2">
+            <BaseButton
+                type="primary"
+                :is-loading="isLoading"
+                :disabled="disabled || isWalletAuthorized"
+                @click="$emit('authorizeWallet')"
+            >
+                <span v-if="isLoading">Authorizing...</span>
+                <span v-else-if="!isWalletAuthorized">Authorize DAI Transactions</span>
+                <span v-else>Already authorized</span>
+            </BaseButton>
+        </div>
+    </BasePanel>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import BaseButton from '~/components/common/BaseButton.vue';
+import BasePanel from '~/components/common/BasePanel.vue';
+import TextBlock from '~/components/common/TextBlock.vue';
+import Explain from '~/components/utils/Explain.vue';
+// import FormatAddress from '~/components/utils/FormatAddress.vue';
+
+export default Vue.extend({
+    components: {
+        BaseButton,
+        BasePanel,
+        TextBlock,
+        Explain,
+        // FormatAddress,
+    },
+    props: {
+        isWalletAuthorized: {
+            type: Boolean,
+            required: true,
+        },
+        disabled: {
+            type: Boolean,
+            default: false,
+        },
+        isLoading: {
+            type: Boolean,
+            default: false,
+        },
+        isExplanationsShown: {
+            type: Boolean,
+            default: true,
+        },
+        walletAddress: {
+            type: String,
+            default: '',
+        },
+    },
+    computed: {
+        currentStateAndTitle(): PanelProps {
+            if (!this.walletAddress) {
+                return {
+                    name: 'inactive',
+                    title: 'Please connect a wallet',
+                };
+            }
+            if (!this.isWalletAuthorized) {
+                return {
+                    name: 'incorrect',
+                    title: 'The wallet is not yet authorized to execute DAI transactions',
+                };
+            }
+            return {
+                name: 'correct',
+                title: 'The wallet is authorized to execute DAI transactions',
+            };
+        },
+    },
+    watch: {
+        currentStateAndTitle: {
+            immediate: true,
+            handler(newCurrentStateAndTitle) {
+                this.$emit('update:isCorrect', newCurrentStateAndTitle.name === 'correct');
+            },
+        },
+    },
+});
+</script>

--- a/frontend/components/panels/WalletDaiCheckPanel.stories.ts
+++ b/frontend/components/panels/WalletDaiCheckPanel.stories.ts
@@ -1,7 +1,0 @@
-import { storiesOf } from '@storybook/vue';
-import WalletDaiCheckPanel from './WalletDaiCheckPanel.vue';
-
-storiesOf('Panels/WalletDaiCheckPanel', module).add('Default', () => ({
-    components: { WalletDaiCheckPanel },
-    template: `<WalletDaiCheckPanel/>`,
-}));

--- a/frontend/components/panels/WalletDaiCheckPanel.stories.ts
+++ b/frontend/components/panels/WalletDaiCheckPanel.stories.ts
@@ -1,0 +1,7 @@
+import { storiesOf } from '@storybook/vue';
+import WalletDaiCheckPanel from './WalletDaiCheckPanel.vue';
+
+storiesOf('Panels/WalletDaiCheckPanel', module).add('Default', () => ({
+    components: { WalletDaiCheckPanel },
+    template: `<WalletDaiCheckPanel/>`,
+}));

--- a/frontend/components/panels/WalletDaiCheckPanel.vue
+++ b/frontend/components/panels/WalletDaiCheckPanel.vue
@@ -1,7 +1,7 @@
 <template>
     <BasePanel class="WalletDaiCheckPanel">
         <template #[currentStateAndTitle.name]>{{ currentStateAndTitle.title }}</template>
-        <TextBlock>
+        <TextBlock v-if="isExplanationsShown">
             If you do not have DAI funds to deposit yet, there are several ways to obtain them:
             <ul class="list-disc list-inside">
                 <li>
@@ -15,10 +15,10 @@
                     <FormatAddress type="address" :value="tokenAddressDai" shorten />)
                 </li>
             </ul>
-            <div class="flex justify-end my-2">
-                <BaseButton @click="$emit('refresh')">Refresh wallet balance</BaseButton>
-            </div>
         </TextBlock>
+        <div class="flex justify-end my-2">
+            <BaseButton @click="$emit('refresh')">Refresh wallet balance</BaseButton>
+        </div>
     </BasePanel>
 </template>
 
@@ -54,6 +54,10 @@ export default Vue.extend({
         tokenAddressDai: {
             type: String,
             default: undefined,
+        },
+        isExplanationsShown: {
+            type: Boolean,
+            default: true,
         },
     },
     computed: {

--- a/frontend/components/panels/WalletDaiCheckPanel.vue
+++ b/frontend/components/panels/WalletDaiCheckPanel.vue
@@ -90,5 +90,13 @@ export default Vue.extend({
             }
         },
     },
+    watch: {
+        currentStateAndTitle: {
+            immediate: true,
+            handler(newCurrentStateAndTitle) {
+                this.$emit('update:isCorrect', newCurrentStateAndTitle.name === 'correct');
+            },
+        },
+    },
 });
 </script>

--- a/frontend/components/panels/WalletDaiCheckPanel.vue
+++ b/frontend/components/panels/WalletDaiCheckPanel.vue
@@ -1,0 +1,94 @@
+<template>
+    <BasePanel class="WalletDaiCheckPanel">
+        <template #[currentStateAndTitle.name]>{{ currentStateAndTitle.title }}</template>
+        <TextBlock>
+            If you do not have DAI funds to deposit yet, there are several ways to obtain them:
+            <ul class="list-disc list-inside">
+                <li>
+                    By borrowing DAI against a collateral in the
+                    <a href="https://oasis.app/" target="_blank">oasis.app</a>
+                </li>
+                <li>
+                    By purchasing it on a decentralized exchange like
+                    <a href="https://uniswap.org/" target="_blank">uniswap.org</a> (correct DAI token address used on
+                    the “{{ networkTitle }}” network is
+                    <FormatAddress type="address" :value="tokenAddressDai" shorten />)
+                </li>
+            </ul>
+            <div class="flex justify-end my-2">
+                <BaseButton @click="$emit('refresh')">Refresh wallet balance</BaseButton>
+            </div>
+        </TextBlock>
+    </BasePanel>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import BigNumber from 'bignumber.js';
+import { getNetworkConfigByType } from 'auctions-core/src/constants/NETWORKS';
+import BaseButton from '~/components/common/BaseButton.vue';
+import BasePanel from '~/components/common/BasePanel.vue';
+import TextBlock from '~/components/common/TextBlock.vue';
+import FormatAddress from '~/components/utils/FormatAddress.vue';
+
+export default Vue.extend({
+    components: {
+        BaseButton,
+        BasePanel,
+        TextBlock,
+        FormatAddress,
+    },
+    props: {
+        walletDai: {
+            type: Object as Vue.PropType<BigNumber>,
+            default: undefined,
+        },
+        wantToDepositDai: {
+            type: Object as Vue.PropType<BigNumber>,
+            default: undefined,
+        },
+        network: {
+            type: String,
+            default: undefined,
+        },
+        tokenAddressDai: {
+            type: String,
+            default: undefined,
+        },
+    },
+    computed: {
+        currentStateAndTitle(): PanelProps {
+            if (!this.walletDai) {
+                return {
+                    name: 'inactive',
+                    title: 'Please connect a wallet',
+                };
+            }
+            if (!this.wantToDepositDai) {
+                return {
+                    name: 'inactive',
+                    title: 'Please enter the value to deposit first',
+                };
+            }
+            const isTooSmall = this.wantToDepositDai?.isGreaterThan(this.walletDai || new BigNumber(0));
+            if (isTooSmall) {
+                return {
+                    name: 'incorrect',
+                    title: 'The sufficient amount of DAI is not present in the connected wallet',
+                };
+            }
+            return {
+                name: 'correct',
+                title: 'The sufficient amount of DAI is present in the connected wallet',
+            };
+        },
+        networkTitle(): string {
+            try {
+                return getNetworkConfigByType(this.network).title;
+            } catch {
+                return this.network;
+            }
+        },
+    },
+});
+</script>

--- a/frontend/components/panels/WalletDaiDepositCheckPanel.vue
+++ b/frontend/components/panels/WalletDaiDepositCheckPanel.vue
@@ -1,5 +1,5 @@
 <template>
-    <BasePanel class="WalletDaiCheckPanel">
+    <BasePanel class="WalletDaiDepositCheckPanel">
         <template #[currentStateAndTitle.name]>{{ currentStateAndTitle.title }}</template>
         <TextBlock v-if="isExplanationsShown">
             If you do not have DAI funds to deposit yet, there are several ways to obtain them:
@@ -16,8 +16,10 @@
                 </li>
             </ul>
         </TextBlock>
-        <div class="flex justify-end my-2">
-            <BaseButton @click="$emit('refresh')">Refresh wallet balance</BaseButton>
+        <div class="flex justify-end mt-2">
+            <BaseButton :disabled="disabled" :is-loading="isLoading" @click="$emit('refresh')"
+                >Refresh wallet balance</BaseButton
+            >
         </div>
     </BasePanel>
 </template>
@@ -43,7 +45,7 @@ export default Vue.extend({
             type: Object as Vue.PropType<BigNumber>,
             default: undefined,
         },
-        wantToDepositDai: {
+        desiredAmount: {
             type: Object as Vue.PropType<BigNumber>,
             default: undefined,
         },
@@ -54,6 +56,14 @@ export default Vue.extend({
         tokenAddressDai: {
             type: String,
             default: undefined,
+        },
+        disabled: {
+            type: Boolean,
+            default: false,
+        },
+        isLoading: {
+            type: Boolean,
+            default: false,
         },
         isExplanationsShown: {
             type: Boolean,
@@ -68,13 +78,19 @@ export default Vue.extend({
                     title: 'Please connect a wallet',
                 };
             }
-            if (!this.wantToDepositDai) {
+            if (!this.desiredAmount) {
                 return {
                     name: 'inactive',
                     title: 'Please enter the value to deposit first',
                 };
             }
-            const isTooSmall = this.wantToDepositDai?.isGreaterThan(this.walletDai || new BigNumber(0));
+            if (this.desiredAmount.isLessThan(0)) {
+                return {
+                    name: 'incorrect',
+                    title: 'The amount can not be negative',
+                };
+            }
+            const isTooSmall = this.desiredAmount?.isGreaterThan(this.walletDai || new BigNumber(0));
             if (isTooSmall) {
                 return {
                     name: 'incorrect',

--- a/frontend/components/panels/WalletDaiDepositCheckPanel.vue
+++ b/frontend/components/panels/WalletDaiDepositCheckPanel.vue
@@ -1,6 +1,6 @@
 <template>
-    <BasePanel class="WalletDaiDepositCheckPanel">
-        <template #[currentStateAndTitle.name]>{{ currentStateAndTitle.title }}</template>
+    <BasePanel :current-state="currentStateAndTitle.name" class="WalletDaiDepositCheckPanel">
+        <template #title>{{ currentStateAndTitle.title }}</template>
         <TextBlock v-if="isExplanationsShown">
             If you do not have DAI funds to deposit yet, there are several ways to obtain them:
             <ul class="list-disc list-inside">

--- a/frontend/components/panels/WalletDaiDepositCheckPanel.vue
+++ b/frontend/components/panels/WalletDaiDepositCheckPanel.vue
@@ -55,7 +55,7 @@ export default Vue.extend({
         },
         tokenAddressDai: {
             type: String,
-            default: undefined,
+            default: '',
         },
         disabled: {
             type: Boolean,

--- a/frontend/components/panels/WalletVatDaiWithdrawCheckPanel.vue
+++ b/frontend/components/panels/WalletVatDaiWithdrawCheckPanel.vue
@@ -1,20 +1,9 @@
 <template>
-    <BasePanel :current-state="currentStateAndTitle.name" class="WalletDaiDepositCheckPanel">
+    <BasePanel :current-state="currentStateAndTitle.name" class="WalletVatDaiWithdrawCheckPanel">
         <template #title>{{ currentStateAndTitle.title }}</template>
         <TextBlock v-if="isExplanationsShown">
-            If you do not have DAI funds to deposit yet, there are several ways to obtain them:
-            <ul class="list-disc list-inside">
-                <li>
-                    By borrowing DAI against a collateral in the
-                    <a href="https://oasis.app/" target="_blank">oasis.app</a>
-                </li>
-                <li>
-                    By purchasing it on a decentralized exchange like
-                    <a href="https://uniswap.org/" target="_blank">uniswap.org</a> (correct DAI token address used on
-                    the “{{ networkTitle }}” network is
-                    <FormatAddress type="address" :value="tokenAddressDai" shorten />)
-                </li>
-            </ul>
+            The amount of <FormatCurrency :value="desiredAmount" currency="DAI" /> is not present in the VAT and needs
+            to be deposited there before it can be withdrawn.
         </TextBlock>
         <div class="flex justify-end mt-2">
             <BaseButton :disabled="disabled" :is-loading="isLoading" @click="$emit('refresh')"
@@ -27,34 +16,25 @@
 <script lang="ts">
 import Vue from 'vue';
 import BigNumber from 'bignumber.js';
-import { getNetworkConfigByType } from 'auctions-core/src/constants/NETWORKS';
 import BaseButton from '~/components/common/BaseButton.vue';
 import BasePanel from '~/components/common/BasePanel.vue';
 import TextBlock from '~/components/common/TextBlock.vue';
-import FormatAddress from '~/components/utils/FormatAddress.vue';
+import FormatCurrency from '~/components/utils/FormatCurrency.vue';
 
 export default Vue.extend({
     components: {
         BaseButton,
         BasePanel,
         TextBlock,
-        FormatAddress,
+        FormatCurrency,
     },
     props: {
-        walletDai: {
+        walletVatDai: {
             type: Object as Vue.PropType<BigNumber>,
             default: undefined,
         },
         desiredAmount: {
             type: Object as Vue.PropType<BigNumber>,
-            default: undefined,
-        },
-        network: {
-            type: String,
-            default: undefined,
-        },
-        tokenAddressDai: {
-            type: String,
             default: undefined,
         },
         disabled: {
@@ -72,7 +52,7 @@ export default Vue.extend({
     },
     computed: {
         currentStateAndTitle(): PanelProps {
-            if (!this.walletDai) {
+            if (!this.walletVatDai) {
                 return {
                     name: 'inactive',
                     title: 'Please connect a wallet',
@@ -90,24 +70,17 @@ export default Vue.extend({
                     title: 'The amount can not be negative',
                 };
             }
-            const isTooSmall = this.desiredAmount.isGreaterThan(this.walletDai);
+            const isTooSmall = this.desiredAmount.isGreaterThan(this.walletVatDai);
             if (isTooSmall) {
                 return {
                     name: 'incorrect',
-                    title: 'The sufficient amount of DAI is not present in the connected wallet',
+                    title: 'The sufficient amount is not present in the VAT',
                 };
             }
             return {
                 name: 'correct',
-                title: 'The sufficient amount of DAI is present in the connected wallet',
+                title: 'The sufficient amount is present in the VAT',
             };
-        },
-        networkTitle(): string {
-            try {
-                return getNetworkConfigByType(this.network).title;
-            } catch {
-                return this.network;
-            }
         },
     },
     watch: {

--- a/frontend/components/transaction/AccessDaiBlock.vue
+++ b/frontend/components/transaction/AccessDaiBlock.vue
@@ -1,7 +1,7 @@
 <template>
     <div>
         <TextBlock v-if="isExplanationsShown" title="Access to DAI">
-            To bid on an auction with Dai, first funds need to be deposited to the
+            To bid on an auction with DAI, first funds need to be deposited to the
             <Explain text="VAT">
                 The
                 <a

--- a/frontend/components/transaction/AuthorisationBlock.stories.js
+++ b/frontend/components/transaction/AuthorisationBlock.stories.js
@@ -10,7 +10,7 @@ const common = {
     data() {
         return {
             isLoading: false,
-            isWalletAuthorised: false,
+            isWalletAuthorized: false,
             isCollateralAuthorised: false,
             auctionTransaction: fakeAuctionTransaction,
             currencyType: faker.finance.currencyCode(),
@@ -20,7 +20,7 @@ const common = {
         authorizeWallet() {
             this.isLoading = true;
             setTimeout(() => {
-                this.isWalletAuthorised = true;
+                this.isWalletAuthorized = true;
                 this.isLoading = false;
             }, 1000);
         },
@@ -38,7 +38,7 @@ storiesOf('Transaction/AuthorisationBlock', module)
     .add('Default', () => ({
         ...common,
         template:
-            '<AuthorisationBlock :auction-transaction="auctionTransaction" :isLoading="isLoading" :isWalletAuthorised="isWalletAuthorised" :isCollateralAuthorised="isCollateralAuthorised"  @authorizeWallet="authorizeWallet" @authorizeCollateral="authorizeCollateral" />',
+            '<AuthorisationBlock :auction-transaction="auctionTransaction" :isLoading="isLoading" :isWalletAuthorized="isWalletAuthorized" :isCollateralAuthorised="isCollateralAuthorised"  @authorizeWallet="authorizeWallet" @authorizeCollateral="authorizeCollateral" />',
     }))
     .add('Disabled', () => ({
         ...common,
@@ -55,5 +55,5 @@ storiesOf('Transaction/AuthorisationBlock', module)
     .add('Authorized', () => ({
         ...common,
         template:
-            '<AuthorisationBlock :isWalletAuthorised="true" :isCollateralAuthorised="true" :auction-transaction="auctionTransaction"/>',
+            '<AuthorisationBlock :isWalletAuthorized="true" :isCollateralAuthorised="true" :auction-transaction="auctionTransaction"/>',
     }));

--- a/frontend/components/transaction/AuthorisationBlock.vue
+++ b/frontend/components/transaction/AuthorisationBlock.vue
@@ -133,7 +133,7 @@ export default Vue.extend({
             type: Boolean,
             default: false,
         },
-        isWalletAuthorised: {
+        isWalletAuthorized: {
             type: Boolean,
             default: false,
         },
@@ -152,7 +152,7 @@ export default Vue.extend({
     },
     computed: {
         walletAuthorizationState(): string {
-            if (this.isWalletAuthorised) {
+            if (this.isWalletAuthorized) {
                 return 'authorized';
             }
             if (this.isLoading) {
@@ -164,7 +164,7 @@ export default Vue.extend({
             return 'notAuthorized';
         },
         collateralAuthorizationState(): string {
-            if (!this.isWalletAuthorised) {
+            if (!this.isWalletAuthorized) {
                 return 'disabled';
             }
             if (this.isCollateralAuthorised) {

--- a/frontend/components/transaction/BidTransaction.stories.js
+++ b/frontend/components/transaction/BidTransaction.stories.js
@@ -18,7 +18,7 @@ const data = {
     isDepositing: false,
     isAuthorizing: false,
     isExecuting: false,
-    isWalletAuthorised: false,
+    isWalletAuthorized: false,
     isDaiAccessGranted: false,
     isDeposited: false,
     authorisedCollaterals: [],
@@ -47,7 +47,7 @@ const common = {
             this.isConnecting = true;
             setTimeout(() => {
                 this.walletAddress = null;
-                this.isWalletAuthorised = false;
+                this.isWalletAuthorized = false;
                 this.authorisedCollaterals = [];
                 this.transactionAddress = null;
                 this.isConnecting = false;
@@ -71,7 +71,7 @@ const common = {
         authorizeWallet() {
             this.isAuthorizing = true;
             setTimeout(() => {
-                this.isWalletAuthorised = true;
+                this.isWalletAuthorized = true;
                 this.isAuthorizing = false;
             }, 1000);
         },
@@ -112,7 +112,7 @@ const common = {
         :isDepositing="isDepositing"
         :isAuthorizing="isAuthorizing"
         :isExecuting="isExecuting"
-        :isWalletAuthorised="isWalletAuthorised"
+        :isWalletAuthorized="isWalletAuthorized"
         :isDaiAccessGranted="isDaiAccessGranted"
         :authorisedCollaterals="authorisedCollaterals"
         :walletAddress="walletAddress"

--- a/frontend/components/transaction/BidTransaction.stories.js
+++ b/frontend/components/transaction/BidTransaction.stories.js
@@ -18,7 +18,6 @@ const data = {
     isAuthorizing: false,
     isExecuting: false,
     isWalletAuthorized: false,
-    isDaiAccessGranted: false,
     isDeposited: false,
     authorisedCollaterals: [],
     walletAddress: null,
@@ -92,7 +91,6 @@ const common = {
         :isAuthorizing="isAuthorizing"
         :isExecuting="isExecuting"
         :isWalletAuthorized="isWalletAuthorized"
-        :isDaiAccessGranted="isDaiAccessGranted"
         :authorisedCollaterals="authorisedCollaterals"
         :walletAddress="walletAddress"
         :walletDai="walletDai"

--- a/frontend/components/transaction/BidTransaction.vue
+++ b/frontend/components/transaction/BidTransaction.vue
@@ -46,7 +46,7 @@
             :disabled="!isEnoughDeposited || !auctionTransaction.isActive || !isDaiAccessGranted"
             :auction-transaction="auctionTransaction"
             :is-loading="isAuthorizing"
-            :is-wallet-authorised="isWalletAuthorised"
+            :is-wallet-authorized="isWalletAuthorized"
             :is-collateral-authorised="isCollateralAuthorised"
             :is-explanations-shown="isExplanationsShown"
             @authorizeWallet="$emit('authorizeWallet')"
@@ -56,7 +56,7 @@
             :auction-transaction="auctionTransaction"
             :transaction-amount-dai="transactionAmountDai"
             :amount-to-receive="amountToReceive"
-            :disabled="!auctionTransaction.isActive || !isWalletAuthorised || !isCollateralAuthorised"
+            :disabled="!auctionTransaction.isActive || !isWalletAuthorized || !isCollateralAuthorised"
             :is-loading="isExecuting"
             :is-explanations-shown="isExplanationsShown"
             @execute="$emit('execute', { id: auctionTransaction.id })"
@@ -112,7 +112,7 @@ export default Vue.extend({
             type: Boolean,
             default: false,
         },
-        isWalletAuthorised: {
+        isWalletAuthorized: {
             type: Boolean,
             default: false,
         },

--- a/frontend/components/transaction/BidTransaction.vue
+++ b/frontend/components/transaction/BidTransaction.vue
@@ -47,7 +47,9 @@
             :auction-transaction="auctionTransaction"
             :transaction-bid-amount="transactionBidAmount"
             :amount-to-receive="amountToReceive"
-            :disabled="!auctionTransaction.isActive || !isWalletAuthorized || !isCollateralAuthorised"
+            :disabled="
+                !auctionTransaction.isActive || !isWalletAuthorized || !isCollateralAuthorised || !isEnoughDeposited
+            "
             :is-loading="isExecuting"
             :is-explanations-shown="isExplanationsShown"
             @bidWithDai="$emit('bidWithDai', { id: auctionTransaction.id, bidAmountDai: transactionBidAmount })"

--- a/frontend/components/transaction/SwapTransaction.stories.js
+++ b/frontend/components/transaction/SwapTransaction.stories.js
@@ -17,7 +17,7 @@ const common = {
             isConnecting: false,
             isAuthorizing: false,
             isExecuting: false,
-            isWalletAuthorised: false,
+            isWalletAuthorized: false,
             authorisedCollaterals: [],
             walletAddress: null,
             transactionAddress: null,
@@ -35,7 +35,7 @@ const common = {
             this.isConnecting = true;
             setTimeout(() => {
                 this.walletAddress = null;
-                this.isWalletAuthorised = false;
+                this.isWalletAuthorized = false;
                 this.authorisedCollaterals = [];
                 this.transactionAddress = null;
                 this.isConnecting = false;
@@ -44,7 +44,7 @@ const common = {
         authorizeWallet() {
             this.isAuthorizing = true;
             setTimeout(() => {
-                this.isWalletAuthorised = true;
+                this.isWalletAuthorized = true;
                 this.isAuthorizing = false;
             }, 1000);
         },
@@ -70,7 +70,7 @@ storiesOf('Transaction/SwapTransaction', module)
     .add('Default', () => ({
         ...common,
         template:
-            '<SwapTransaction :auction-transaction="auctionTransaction" :isConnecting="isConnecting" :isAuthorizing="isAuthorizing" :isWalletAuthorised="isWalletAuthorised" :authorisedCollaterals="authorisedCollaterals" :isExecuting="isExecuting" :walletAddress="walletAddress" @connect="connect" @disconnect="disconnect" @authorizeCollateral="authorizeCollateral" @authorizeWallet="authorizeWallet" @execute="execute" />',
+            '<SwapTransaction :auction-transaction="auctionTransaction" :isConnecting="isConnecting" :isAuthorizing="isAuthorizing" :isWalletAuthorized="isWalletAuthorized" :authorisedCollaterals="authorisedCollaterals" :isExecuting="isExecuting" :walletAddress="walletAddress" @connect="connect" @disconnect="disconnect" @authorizeCollateral="authorizeCollateral" @authorizeWallet="authorizeWallet" @execute="execute" />',
     }))
     .add('Inactive Auction', () => ({
         components: { SwapTransaction },

--- a/frontend/components/transaction/SwapTransaction.vue
+++ b/frontend/components/transaction/SwapTransaction.vue
@@ -43,7 +43,7 @@
             :disabled="!isConnected || !auctionTransaction.isActive"
             :auction-transaction="auctionTransaction"
             :is-loading="isAuthorizing"
-            :is-wallet-authorised="isWalletAuthorised"
+            :is-wallet-authorized="isWalletAuthorized"
             :is-collateral-authorised="isCollateralAuthorised"
             :is-explanations-shown="isExplanationsShown"
             @authorizeWallet="$emit('authorizeWallet')"
@@ -52,7 +52,7 @@
         <ExecutionBlock
             :disabled="
                 !isCollateralAuthorised ||
-                !isWalletAuthorised ||
+                !isWalletAuthorized ||
                 !auctionTransaction.isActive ||
                 auctionTransaction.isFinished
             "
@@ -106,7 +106,7 @@ export default Vue.extend({
             type: Boolean,
             default: false,
         },
-        isWalletAuthorised: {
+        isWalletAuthorized: {
             type: Boolean,
             default: false,
         },

--- a/frontend/components/transaction/TransactionMessage.vue
+++ b/frontend/components/transaction/TransactionMessage.vue
@@ -14,9 +14,8 @@
                 </a>
                 due to changing busyness of the Ethereum network. However, you can look up the current average gas
                 price
-                <a href="https://ethgasstation.info/" target="_blank"> here </a>
-            </Explain>
-            . The amount can be edited by the participant to influence the speed of the transaction.
+                <a href="https://ethgasstation.info/" target="_blank"> here </a> </Explain
+            >. The amount can be edited by the participant to influence the speed of the transaction.
             <div v-if="showDifferentWalletInfo">
                 <br />
                 By default, the profit from a successful bidding will be sent to the same wallet which executed the

--- a/frontend/components/utils/BidInput.vue
+++ b/frontend/components/utils/BidInput.vue
@@ -2,8 +2,8 @@
     <BaseValueInput
         :input-value="transactionBidAmount"
         :max-value="totalPrice"
-        :min-value="minimumDepositDai"
-        :disabled="!canWithdraw"
+        :min-value="minimumBidDai"
+        :disabled="!disabled"
         :validator="validator"
         @update:inputValue="$emit('update:transactionBidAmount', $event)"
     />

--- a/frontend/components/utils/BidInput.vue
+++ b/frontend/components/utils/BidInput.vue
@@ -1,31 +1,23 @@
 <template>
-    <div class="w-full relative dark:text-gray-300">
-        <Tooltip :visible="!!error" placement="topLeft" :title="error">
-            <Tooltip placement="topLeft" :title="isTooSmallToPartiallyTakeTooltipContent">
-                <Input
-                    v-model="amountToBidInput"
-                    :disabled="isDisabled"
-                    class="Input"
-                    :class="{ Error: error }"
-                    @focus="hideTotalPrice()"
-                    @blur="showTotalPriceIfEmpty()"
-                />
-                <div v-if="!amountToBid" class="Overlay TotalPrice">
-                    <format-currency v-if="totalPrice" :value="totalPrice" :class="{ 'opacity-50': isDisabled }" />
-                </div>
-                <span class="Overlay right-1" :class="{ 'opacity-50': isDisabled }">DAI</span>
-            </Tooltip>
-        </Tooltip>
-    </div>
+    <BaseValueInput
+        :input-value="amountToBid"
+        :max-value="totalPrice"
+        :min-value="minimumDepositDai"
+        :disabled="!canWithdraw"
+        :validator="validator"
+        @update:inputValue="$emit('update:amountToBid', $event)"
+    />
 </template>
 
 <script lang="ts">
 import Vue from 'vue';
 import BigNumber from 'bignumber.js';
-import { Input, Tooltip } from 'ant-design-vue';
-import FormatCurrency from './FormatCurrency.vue';
+import BaseValueInput from '~/components/common/BaseValueInput.vue';
+
 export default Vue.extend({
-    components: { FormatCurrency, Tooltip, Input },
+    components: {
+        BaseValueInput,
+    },
     props: {
         totalPrice: {
             type: Object as Vue.PropType<BigNumber>,
@@ -44,116 +36,16 @@ export default Vue.extend({
             default: false,
         },
     },
-    data() {
-        return {
-            amountToBidInput: '' as string,
-        };
-    },
-    computed: {
-        isInputEmpty(): boolean {
-            return this.amountToBidInput.trim() === '';
-        },
-        amountToBidInputParsed(): BigNumber | undefined {
-            if (this.isInputEmpty) {
-                return undefined;
-            }
-            const amountToBid = new BigNumber(this.amountToBidInput);
-            return amountToBid;
-        },
-        error(): string | undefined {
-            const maximumBid = this.totalPrice?.minus(this.minimumDepositDai);
-            if (
-                this.amountToBidInputParsed?.isGreaterThan(maximumBid) ||
-                this.amountToBidInputParsed?.isLessThan(this.minimumDepositDai)
-            ) {
-                return `The value can only be between ${this.minimumDepositDai.toFixed(2)} and ${maximumBid.toFixed(
-                    2
-                )}`;
-            }
-            return undefined;
-        },
-        isTooSmallToPartiallyTake(): boolean {
-            return this.totalPrice?.isLessThan(this.minimumDepositDai.multipliedBy(2));
-        },
-        isDisabled(): boolean {
-            return this.disabled || this.isTooSmallToPartiallyTake;
-        },
-        isTooSmallToPartiallyTakeTooltipContent(): string {
-            if (this.isTooSmallToPartiallyTake) {
-                return 'The value can not be changed since the leftover part will be too small';
-            }
-            return '';
-        },
-    },
-    watch: {
-        amountToBidInput(_newAmountToBidInput: string, oldAmountToBidInput: string) {
-            if (this.error) {
-                this.$emit('update:amountToBid', new BigNumber(NaN));
-                return;
-            }
-            if (!this.amountToBidInputParsed) {
-                return;
-            }
-            if (this.amountToBidInputParsed?.isNaN()) {
-                this.amountToBidInput = oldAmountToBidInput || '';
-                return;
-            }
-            this.$emit('update:amountToBid', this.amountToBidInputParsed);
-        },
-        amountToBid(newAmountToBid: BigNumber | undefined) {
-            if (!newAmountToBid) {
-                this.amountToBidInput = '';
-                return;
-            }
-            if (newAmountToBid.isEqualTo(this.minimumDepositDai) && !newAmountToBid.isZero()) {
-                this.amountToBidInput = newAmountToBid.toFixed();
-            }
-        },
-        isTooSmallToPartiallyTake(newVal) {
-            if (newVal) {
-                this.$emit('update:amountToBid', undefined);
-            }
-        },
-    },
     methods: {
-        hideTotalPrice(): void {
-            if (!this.amountToBid) {
-                this.$emit('update:amountToBid', new BigNumber(NaN));
+        validator(currentValue: BigNumber, minValue: BigNumber, maxValue: BigNumber) {
+            const bidTopLimit = maxValue?.minus(minValue);
+            if (currentValue?.isGreaterThan(bidTopLimit) || currentValue?.isLessThan(minValue)) {
+                throw new Error(`The value can only be between ${minValue.toFixed(2)} and ${bidTopLimit.toFixed(2)}`);
             }
-        },
-        showTotalPriceIfEmpty(): void {
-            if (this.isInputEmpty) {
-                this.$emit('update:amountToBid', undefined);
+            if (maxValue?.isLessThan(minValue.multipliedBy(2))) {
+                throw new Error('The value can not be changed since the leftover part will be too small');
             }
         },
     },
 });
 </script>
-
-<style scoped>
-.Input {
-    @apply text-right;
-
-    padding-right: 30px;
-}
-
-.Error {
-    @apply border-red-500 hover:border-red-400;
-}
-
-.Error:focus {
-    @apply border-red-400;
-
-    box-shadow: 0 0 3px rgb(239, 68, 68);
-}
-
-.Overlay {
-    @apply absolute pointer-events-none;
-
-    top: 5.5px;
-}
-
-.TotalPrice {
-    right: 30px;
-}
-</style>

--- a/frontend/components/utils/BidInput.vue
+++ b/frontend/components/utils/BidInput.vue
@@ -38,6 +38,9 @@ export default Vue.extend({
     },
     methods: {
         validator(currentValue: BigNumber, minValue: BigNumber, maxValue: BigNumber) {
+            if (!currentValue || !minValue || !maxValue) {
+                return;
+            }
             const bidTopLimit = maxValue?.minus(minValue);
             if (currentValue?.isGreaterThan(bidTopLimit) || currentValue?.isLessThan(minValue)) {
                 throw new Error(`The value can only be between ${minValue.toFixed(2)} and ${bidTopLimit.toFixed(2)}`);

--- a/frontend/components/utils/WalletSelector.stories.js
+++ b/frontend/components/utils/WalletSelector.stories.js
@@ -1,7 +1,7 @@
 import { storiesOf } from '@storybook/vue';
 import WalletSelector from './WalletSelector.vue';
 
-storiesOf('WalletSelector/WalletSelector', module).add('Default', () => ({
+storiesOf('Modals/WalletSelector', module).add('Default', () => ({
     components: { WalletSelector },
     template: `<WalletSelector/>`,
 }));

--- a/frontend/components/wallet/WalletDepositWithdrawBlock.vue
+++ b/frontend/components/wallet/WalletDepositWithdrawBlock.vue
@@ -37,6 +37,7 @@
                     :want-to-deposit-dai="depositAmount || maxDeposit"
                     :token-address-dai="tokenAddressDai"
                     :network="network"
+                    :is-explanations-shown="isExplanationsShown"
                     @refresh="$emit('refresh')"
                 />
             </div>

--- a/frontend/components/wallet/WalletDepositWithdrawBlock.vue
+++ b/frontend/components/wallet/WalletDepositWithdrawBlock.vue
@@ -2,20 +2,7 @@
     <div class="WalletDepositWithDrawBlock">
         <TextBlock v-if="isExplanationsShown" title="Moving funds">
             The DAI funds can be moved freely between VAT and your wallet without any extra conversion. You only need
-            to be aware that each transfer incurs transaction fees. Also, if you do not have DAI funds to deposit yet,
-            there are several ways to obtain it:
-            <ul class="list-disc list-inside">
-                <li>
-                    By borrowing DAI against a collateral in the
-                    <a href="https://oasis.app/" target="_blank">oasis.app</a>
-                </li>
-                <li>
-                    By purchasing it on a decentralized exchange like
-                    <a href="https://uniswap.org/" target="_blank">uniswap.org</a> (correct DAI token address used on
-                    the “{{ networkTitle }}” network is
-                    <FormatAddress type="address" :value="tokenAddressDai || ''" shorten />)
-                </li>
-            </ul>
+            to be aware that each transfer incurs transaction fees.
         </TextBlock>
         <form class="flex flex-col gap-4" @submit.prevent="submit">
             <RadioGroup
@@ -28,20 +15,30 @@
                 <RadioButton value="withdraw" class="w-full text-center"> Withdraw </RadioButton>
             </RadioGroup>
 
-            <BidInput
+            <BaseValueInput
                 v-show="selectedMethod === 'deposit'"
-                :amount-to-bid.sync="depositAmount"
+                :input-value.sync="depositAmount"
+                :max-value="maxAllowedDeposit"
+                :min-value="minimumDaiAmount"
                 :disabled="!canDeposit"
-                :total-price="maxAllowedDeposit"
-                :minimum-deposit-dai="minimumDaiAmount"
             />
-            <BidInput
+            <BaseValueInput
                 v-show="selectedMethod === 'withdraw'"
-                :amount-to-bid.sync="withDrawAmount"
+                :input-value.sync="withDrawAmount"
+                :max-value="maxWithdraw"
+                :min-value="minimumDaiAmount"
                 :disabled="!canWithdraw"
-                :total-price="maxWithdraw"
-                :minimum-deposit-dai="minimumDaiAmount"
             />
+
+            <div v-if="selectedMethod === 'deposit'">
+                <WalletDaiCheckPanel
+                    :wallet-dai="maxDeposit"
+                    :want-to-deposit-dai="depositAmount || maxDeposit"
+                    :token-address-dai="tokenAddressDai"
+                    :network="network"
+                    @refresh="$emit('refresh')"
+                />
+            </div>
 
             <BaseButton type="primary" :is-loading="isSubmitting" :disabled="!canSubmit" html-type="submit">
                 <span class="capitalize">{{ selectedMethod }}{{ isSubmitting ? 'ing...' : '' }}</span>
@@ -55,20 +52,20 @@ import Vue from 'vue';
 import { Radio } from 'ant-design-vue';
 import BigNumber from 'bignumber.js';
 import { getNetworkConfigByType } from 'auctions-core/src/constants/NETWORKS';
-import TextBlock from '../common/TextBlock.vue';
-import FormatAddress from '../utils/FormatAddress.vue';
-import BaseButton from '../common/BaseButton.vue';
-import BidInput from '../utils/BidInput';
+import TextBlock from '~/components/common/TextBlock.vue';
+import BaseButton from '~/components/common/BaseButton.vue';
+import BaseValueInput from '~/components/common/BaseValueInput.vue';
+import WalletDaiCheckPanel from '~/components/panels/WalletDaiCheckPanel.vue';
 
 export default Vue.extend({
     name: 'WalletDepositWithdrawBlock',
     components: {
-        BidInput,
+        BaseValueInput,
         BaseButton,
-        FormatAddress,
         TextBlock,
         RadioGroup: Radio.Group,
         RadioButton: Radio.Button,
+        WalletDaiCheckPanel,
     },
     props: {
         network: {
@@ -186,7 +183,7 @@ export default Vue.extend({
 });
 </script>
 
-<style>
+<style scoped>
 .WalletDepositWithDrawBlock {
     @apply flex flex-col gap-4;
 }

--- a/frontend/components/wallet/WalletDepositWithdrawBlock.vue
+++ b/frontend/components/wallet/WalletDepositWithdrawBlock.vue
@@ -32,6 +32,7 @@
 
             <div v-if="selectedMethod === 'deposit'">
                 <WalletDaiCheckPanel
+                    :is-correct.sync="isWalletDaiCheckPassed"
                     :wallet-dai="maxDeposit"
                     :want-to-deposit-dai="depositAmount || maxDeposit"
                     :token-address-dai="tokenAddressDai"
@@ -111,10 +112,11 @@ export default Vue.extend({
             selectedMethod: 'deposit',
             depositAmount: undefined,
             withDrawAmount: undefined,
+            isWalletDaiCheckPassed: false,
         };
     },
     computed: {
-        canDeposit() {
+        canDeposit(): boolean {
             return (
                 !this.isLoading &&
                 !this.isSubmitting &&
@@ -123,7 +125,7 @@ export default Vue.extend({
                 !this.maxDeposit.isZero()
             );
         },
-        canWithdraw() {
+        canWithdraw(): boolean {
             return (
                 !this.isLoading &&
                 !this.isSubmitting &&
@@ -135,6 +137,9 @@ export default Vue.extend({
         canSubmit(): boolean {
             if (this.selectedMethod === 'deposit') {
                 if (!this.canDeposit) {
+                    return false;
+                }
+                if (!this.isWalletDaiCheckPassed) {
                     return false;
                 }
                 if (this.depositAmount === undefined) {

--- a/frontend/components/wallet/WalletDepositWithdrawBlock.vue
+++ b/frontend/components/wallet/WalletDepositWithdrawBlock.vue
@@ -6,7 +6,7 @@
         </TextBlock>
         <form class="flex flex-col gap-4" @submit.prevent="submit">
             <RadioGroup
-                :disabled="isLoading || isSubmitting"
+                :disabled="isLoading || isSubmitting || isAllowanceAmountLoading"
                 :value="selectedMethod"
                 class="flex items-center w-full"
                 @change="handleMethodChange"
@@ -20,14 +20,14 @@
                 :input-value.sync="depositAmount"
                 :max-value="maxDeposit"
                 :min-value="minimumDaiAmount"
-                :disabled="!canDeposit"
+                :disabled="!canDeposit || isAllowanceAmountLoading"
             />
             <BaseValueInput
                 v-show="selectedMethod === 'withdraw'"
-                :input-value.sync="withDrawAmount"
+                :input-value.sync="withdrawAmount"
                 :max-value="maxWithdraw"
                 :min-value="minimumDaiAmount"
-                :disabled="!canWithdraw"
+                :disabled="!canWithdraw || isAllowanceAmountLoading"
             />
 
             <div v-if="selectedMethod === 'deposit'">
@@ -39,7 +39,7 @@
                     :network="network"
                     :is-loading="isLoading"
                     :is-explanations-shown="isExplanationsShown"
-                    :disabled="isLoading || isSubmitting"
+                    :disabled="isLoading || isSubmitting || isAllowanceAmountLoading"
                     @refresh="$emit('refresh')"
                 />
                 <AllowanceAmountCheckPanel
@@ -125,7 +125,7 @@ export default Vue.extend({
             minimumDaiAmount: new BigNumber(0),
             selectedMethod: 'deposit',
             depositAmount: undefined,
-            withDrawAmount: undefined,
+            withdrawAmount: undefined,
             isWalletDaiCheckPassed: false,
             isAllowanceAmountCheckPassed: false,
         };
@@ -165,10 +165,10 @@ export default Vue.extend({
                 if (!this.canWithdraw) {
                     return false;
                 }
-                if (this.withDrawAmount === undefined) {
+                if (this.withdrawAmount === undefined) {
                     return true;
                 }
-                return !this.withDrawAmount.isNaN();
+                return !this.withdrawAmount.isNaN();
             }
             return false;
         },
@@ -189,7 +189,7 @@ export default Vue.extend({
                 this.$emit('deposit', this.depositAmount ?? this.maxDeposit);
             }
             if (this.selectedMethod === 'withdraw') {
-                this.$emit('withdraw', this.withDrawAmount ?? this.maxWithdraw);
+                this.$emit('withdraw', this.withdrawAmount ?? this.maxWithdraw);
             }
         },
     },

--- a/frontend/components/wallet/WalletDepositWithdrawBlock.vue
+++ b/frontend/components/wallet/WalletDepositWithdrawBlock.vue
@@ -22,14 +22,6 @@
                 :min-value="minimumDaiAmount"
                 :disabled="!canDeposit || isAllowanceAmountLoading"
             />
-            <BaseValueInput
-                v-show="selectedMethod === 'withdraw'"
-                :input-value.sync="withdrawAmount"
-                :max-value="maxWithdraw"
-                :min-value="minimumDaiAmount"
-                :disabled="!canWithdraw || isAllowanceAmountLoading"
-            />
-
             <div v-if="selectedMethod === 'deposit'">
                 <WalletDaiDepositCheckPanel
                     :is-correct.sync="isWalletDaiCheckPassed"
@@ -53,6 +45,25 @@
                 />
             </div>
 
+            <BaseValueInput
+                v-show="selectedMethod === 'withdraw'"
+                :input-value.sync="withdrawAmount"
+                :max-value="maxWithdraw"
+                :min-value="minimumDaiAmount"
+                :disabled="!canWithdraw || isAllowanceAmountLoading"
+            />
+            <div v-if="selectedMethod === 'withdraw'">
+                <WalletVatDaiWithdrawCheckPanel
+                    :is-correct.sync="isWalletDaiCheckPassed"
+                    :wallet-vat-dai="maxWithdraw"
+                    :desired-amount="withdrawAmount || maxWithdraw"
+                    :is-loading="isLoading"
+                    :is-explanations-shown="isExplanationsShown"
+                    :disabled="isLoading || isSubmitting || isAllowanceAmountLoading"
+                    @refresh="$emit('refresh')"
+                />
+            </div>
+
             <BaseButton type="primary" :is-loading="isSubmitting" :disabled="!canSubmit" html-type="submit">
                 <span class="capitalize">{{ selectedMethod }}{{ isSubmitting ? 'ing...' : '' }}</span>
             </BaseButton>
@@ -70,6 +81,7 @@ import BaseButton from '~/components/common/BaseButton.vue';
 import BaseValueInput from '~/components/common/BaseValueInput.vue';
 import WalletDaiDepositCheckPanel from '~/components/panels/WalletDaiDepositCheckPanel.vue';
 import AllowanceAmountCheckPanel from '~/components/panels/AllowanceAmountCheckPanel.vue';
+import WalletVatDaiWithdrawCheckPanel from '~/components/panels/WalletVatDaiWithdrawCheckPanel.vue';
 
 export default Vue.extend({
     name: 'WalletDepositWithdrawBlock',
@@ -81,6 +93,7 @@ export default Vue.extend({
         RadioButton: Radio.Button,
         WalletDaiDepositCheckPanel,
         AllowanceAmountCheckPanel,
+        WalletVatDaiWithdrawCheckPanel,
     },
     props: {
         network: {

--- a/frontend/components/wallet/WalletModal.vue
+++ b/frontend/components/wallet/WalletModal.vue
@@ -29,15 +29,6 @@
                 is the set of immutable rules for managing DAI and collaterals which constitutes the core of the Maker
                 Protocol.
             </TextBlock>
-            <!-- <AccessDaiBlock
-                :is-loading="isAllowanceAmountLoading"
-                :is-explanations-shown="isExplanationsShown"
-                :allowance-amount="allowanceAmount"
-                :is-dai-access-granted="
-                    allowanceAmount.isGreaterThanOrEqualTo(walletBalances ? walletBalances.walletDAI : 0)
-                "
-                @grantAccess="$emit('grantAccess')"
-            /> -->
             <WalletDepositWithdrawBlock
                 :network="network"
                 :is-loading="isLoading"
@@ -48,9 +39,11 @@
                 :max-deposit="walletBalances && walletBalances.walletDAI"
                 :max-withdraw="walletBalances && walletBalances.walletVatDAI"
                 :token-address-dai="tokenAddressDai"
+                :is-allowance-amount-loading="isAllowanceAmountLoading"
                 @refresh="$emit('refresh')"
-                @deposit="value => $emit('deposit', value)"
-                @withdraw="value => $emit('withdraw', value)"
+                @deposit="$emit('deposit', $event)"
+                @withdraw="$emit('withdraw', $event)"
+                @setAllowanceAmount="$emit('setAllowanceAmount', $event)"
             />
         </div>
     </modal>

--- a/frontend/components/wallet/WalletModal.vue
+++ b/frontend/components/wallet/WalletModal.vue
@@ -29,7 +29,7 @@
                 is the set of immutable rules for managing DAI and collaterals which constitutes the core of the Maker
                 Protocol.
             </TextBlock>
-            <AccessDaiBlock
+            <!-- <AccessDaiBlock
                 :is-loading="isAllowanceAmountLoading"
                 :is-explanations-shown="isExplanationsShown"
                 :allowance-amount="allowanceAmount"
@@ -37,7 +37,7 @@
                     allowanceAmount.isGreaterThanOrEqualTo(walletBalances ? walletBalances.walletDAI : 0)
                 "
                 @grantAccess="$emit('grantAccess')"
-            />
+            /> -->
             <WalletDepositWithdrawBlock
                 :network="network"
                 :is-loading="isLoading"
@@ -48,6 +48,7 @@
                 :max-deposit="walletBalances && walletBalances.walletDAI"
                 :max-withdraw="walletBalances && walletBalances.walletVatDAI"
                 :token-address-dai="tokenAddressDai"
+                @refresh="$emit('refresh')"
                 @deposit="value => $emit('deposit', value)"
                 @withdraw="value => $emit('withdraw', value)"
             />
@@ -61,12 +62,16 @@ import { Modal } from 'ant-design-vue';
 import { WalletBalances } from 'auctions-core/dist/src/types';
 import BigNumber from 'bignumber.js';
 import TextBlock from '../common/TextBlock.vue';
-import AccessDaiBlock from '../transaction/AccessDaiBlock.vue';
 import WalletTable from './WalletTable.vue';
 import WalletDepositWithdrawBlock from './WalletDepositWithdrawBlock.vue';
 
 export default Vue.extend({
-    components: { AccessDaiBlock, TextBlock, WalletDepositWithdrawBlock, WalletTable, Modal },
+    components: {
+        TextBlock,
+        WalletDepositWithdrawBlock,
+        WalletTable,
+        Modal,
+    },
     props: {
         network: {
             type: String,

--- a/frontend/components/wallet/WalletModal.vue
+++ b/frontend/components/wallet/WalletModal.vue
@@ -35,15 +35,18 @@
                 :is-submitting="isSubmitting"
                 :is-explanations-shown="isExplanationsShown"
                 :allowance-amount="allowanceAmount"
-                :is-withdrawing-allowed="isWithdrawingAllowed"
                 :max-deposit="walletBalances && walletBalances.walletDAI"
                 :max-withdraw="walletBalances && walletBalances.walletVatDAI"
                 :token-address-dai="tokenAddressDai"
+                :wallet-address="walletAddress"
                 :is-allowance-amount-loading="isAllowanceAmountLoading"
+                :is-wallet-authorized="isWalletAuthorized"
+                :is-authorization-loading="isAuthorizationLoading"
                 @refresh="$emit('refresh')"
                 @deposit="$emit('deposit', $event)"
                 @withdraw="$emit('withdraw', $event)"
                 @setAllowanceAmount="$emit('setAllowanceAmount', $event)"
+                @authorizeWallet="$emit('authorizeWallet')"
             />
         </div>
     </modal>
@@ -84,7 +87,7 @@ export default Vue.extend({
         },
         walletAddress: {
             type: String,
-            default: null,
+            default: '',
         },
         walletBalances: {
             type: Object as Vue.PropType<WalletBalances>,
@@ -93,10 +96,6 @@ export default Vue.extend({
         allowanceAmount: {
             type: Object as Vue.PropType<BigNumber>,
             default: undefined,
-        },
-        isWithdrawingAllowed: {
-            type: Boolean,
-            required: true,
         },
         isLoading: {
             type: Boolean,
@@ -115,6 +114,14 @@ export default Vue.extend({
             default: true,
         },
         isAllowanceAmountLoading: {
+            type: Boolean,
+            default: false,
+        },
+        isWalletAuthorized: {
+            type: Boolean,
+            default: false,
+        },
+        isAuthorizationLoading: {
             type: Boolean,
             default: false,
         },

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -10,7 +10,7 @@
             :wallet-address="walletAddress"
             :is-wallet-loading="isWalletLoading"
             :is-authorizing="isAuthorizing"
-            :is-wallet-authorised="isWalletAuthorised"
+            :is-wallet-authorized="isWalletAuthorized"
             :authorised-collaterals="authorisedCollaterals"
             :is-executing="isAuctionBidding"
             :take-event-storage="takeEvents"
@@ -49,7 +49,7 @@ export default Vue.extend({
         }),
         ...mapGetters('authorizations', {
             isAuthorizing: 'isAuthorizationLoading',
-            isWalletAuthorised: 'isWalletAuthorizationDone',
+            isWalletAuthorized: 'isWalletAuthorizationDone',
             authorisedCollaterals: 'collateralAuthorizations',
         }),
         selectedAuctionId: {

--- a/frontend/containers/AuctionsFakeData.vue
+++ b/frontend/containers/AuctionsFakeData.vue
@@ -6,7 +6,7 @@
         :is-granting-access="isGrantingAccess"
         :is-depositing-dai="isDepositingDai"
         :is-authorizing="isAuthorizing"
-        :is-wallet-authorised="isWalletAuthorised"
+        :is-wallet-authorized="isWalletAuthorized"
         :is-dai-access-granted="isDaiAccessGranted"
         :authorised-collaterals="authorisedCollaterals"
         :is-executing="isExecuting"
@@ -50,7 +50,7 @@ export default Vue.extend({
             isDepositingDai: false,
             isAuthorizing: false,
             isExecuting: false,
-            isWalletAuthorised: false,
+            isWalletAuthorized: false,
             isDaiAccessGranted: false,
             isDeposited: false,
             authorisedCollaterals: [] as string[],
@@ -116,7 +116,7 @@ export default Vue.extend({
             this.isConnecting = true;
             setTimeout(() => {
                 this.walletAddress = null;
-                this.isWalletAuthorised = false;
+                this.isWalletAuthorized = false;
                 this.authorisedCollaterals = [];
                 if (this.selectedAuction) {
                     this.selectedAuction.transactionAddress = undefined;
@@ -142,7 +142,7 @@ export default Vue.extend({
         authorizeWallet() {
             this.isAuthorizing = true;
             setTimeout(() => {
-                this.isWalletAuthorised = true;
+                this.isWalletAuthorized = true;
                 this.isAuthorizing = false;
             }, 1000);
         },

--- a/frontend/containers/AuctionsFakeData.vue
+++ b/frontend/containers/AuctionsFakeData.vue
@@ -6,7 +6,6 @@
         :is-depositing-or-withdrawing="isDepositingOrWithdrawing"
         :is-authorizing="isAuthorizing"
         :is-wallet-authorized="isWalletAuthorized"
-        :is-dai-access-granted="isDaiAccessGranted"
         :authorised-collaterals="authorisedCollaterals"
         :is-executing="isExecuting"
         :wallet-address="walletAddress"
@@ -48,7 +47,6 @@ export default Vue.extend({
             isAuthorizing: false,
             isExecuting: false,
             isWalletAuthorized: false,
-            isDaiAccessGranted: false,
             isDeposited: false,
             authorisedCollaterals: [] as string[],
             walletAddress: null as string | null,

--- a/frontend/containers/WalletModalContainer.vue
+++ b/frontend/containers/WalletModalContainer.vue
@@ -7,18 +7,20 @@
         :wallet-address="walletAddress"
         :wallet-balances="walletBalances"
         :allowance-amount="allowanceAmount"
-        :is-withdrawing-allowed="isWalletAuthorizationDone"
         :is-submitting="isDepositingOrWithdrawing"
         :is-wallet-loading="isFetchingBalances"
         :is-loading="isFetchingBalances"
         :is-allowance-amount-loading="isAllowanceAmountLoading"
         :token-address-dai="tokenAddressDai"
+        :is-wallet-authorized="isWalletAuthorized"
+        :is-authorization-loading="isAuthorizationLoading"
         @cancel="setWalletModal(false)"
         @refresh="fetchRelatedData()"
         @connectWallet="openSelectWalletModal()"
         @deposit="depositToVAT"
         @withdraw="withdrawFromVAT"
         @setAllowanceAmount="setAllowanceAmount"
+        @authorizeWallet="authorizeWallet"
     />
 </template>
 
@@ -47,7 +49,8 @@ export default Vue.extend({
             isWalletModalShown: 'getWalletModal',
         }),
         ...mapGetters('authorizations', {
-            isWalletAuthorizationDone: 'isWalletAuthorizationDone',
+            isWalletAuthorized: 'isWalletAuthorizationDone',
+            isAuthorizationLoading: 'isAuthorizationLoading',
             allowanceAmount: 'allowanceAmount',
             isAllowanceAmountLoading: 'isAllowanceAmountLoading',
         }),
@@ -86,7 +89,7 @@ export default Vue.extend({
     },
     methods: {
         ...mapActions('wallet', ['depositToVAT', 'withdrawFromVAT']),
-        ...mapActions('authorizations', ['setAllowanceAmount']),
+        ...mapActions('authorizations', ['setAllowanceAmount', 'authorizeWallet']),
         openSelectWalletModal(): void {
             if (!this.hasAcceptedTerms) {
                 this.$store.commit('modals/setTermsModal', true);

--- a/frontend/containers/WalletModalContainer.vue
+++ b/frontend/containers/WalletModalContainer.vue
@@ -18,7 +18,7 @@
         @connectWallet="openSelectWalletModal()"
         @deposit="depositToVAT"
         @withdraw="withdrawFromVAT"
-        @grantAccess="grantAccess"
+        @setAllowanceAmount="setAllowanceAmount"
     />
 </template>
 
@@ -85,10 +85,8 @@ export default Vue.extend({
         },
     },
     methods: {
-        ...mapActions('wallet', {
-            depositToVAT: 'depositToVAT',
-            withdrawFromVAT: 'withdrawFromVAT',
-        }),
+        ...mapActions('wallet', ['depositToVAT', 'withdrawFromVAT']),
+        ...mapActions('authorizations', ['setAllowanceAmount']),
         openSelectWalletModal(): void {
             if (!this.hasAcceptedTerms) {
                 this.$store.commit('modals/setTermsModal', true);
@@ -98,9 +96,6 @@ export default Vue.extend({
         },
         setWalletModal(open: boolean): void {
             this.$store.commit('modals/setWalletModal', open);
-        },
-        grantAccess(): void {
-            this.$store.dispatch('authorizations/setAllowanceAmount');
         },
         fetchRelatedData(): void {
             this.$store.dispatch('wallet/fetchWalletBalances');

--- a/frontend/package-lock.json
+++ b/frontend/package-lock.json
@@ -9,6 +9,7 @@
       "version": "1.0.0",
       "hasInstallScript": true,
       "dependencies": {
+        "@ivanv/vue-collapse-transition": "^1.0.2",
         "@nuxtjs/dotenv": "^1.4.1",
         "@types/js-cookie": "^3.0.1",
         "animated-number-vue": "^1.0.0",
@@ -3084,6 +3085,11 @@
       "engines": {
         "node": ">=8"
       }
+    },
+    "node_modules/@ivanv/vue-collapse-transition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ivanv/vue-collapse-transition/-/vue-collapse-transition-1.0.2.tgz",
+      "integrity": "sha512-eWEameFXJM/1khcoKbITvKjYYXDP1WKQ/Xf9ItJVPoEjCiOdocR3AgDAERzDrNNg4oWK28gRGi+0ft8Te27zxw=="
     },
     "node_modules/@jest/console": {
       "version": "27.4.2",
@@ -44174,6 +44180,11 @@
       "resolved": "https://registry.npmjs.org/@istanbuljs/schema/-/schema-0.1.3.tgz",
       "integrity": "sha512-ZXRY4jNvVgSVQ8DL3LTcakaAtXwTVUxE81hslsyD2AtoXW/wVob10HkOJ1X/pAlcI7D+2YoZKg5do8G/w6RYgA==",
       "dev": true
+    },
+    "@ivanv/vue-collapse-transition": {
+      "version": "1.0.2",
+      "resolved": "https://registry.npmjs.org/@ivanv/vue-collapse-transition/-/vue-collapse-transition-1.0.2.tgz",
+      "integrity": "sha512-eWEameFXJM/1khcoKbITvKjYYXDP1WKQ/Xf9ItJVPoEjCiOdocR3AgDAERzDrNNg4oWK28gRGi+0ft8Te27zxw=="
     },
     "@jest/console": {
       "version": "27.4.2",

--- a/frontend/package.json
+++ b/frontend/package.json
@@ -32,6 +32,7 @@
     }
   },
   "dependencies": {
+    "@ivanv/vue-collapse-transition": "^1.0.2",
     "@nuxtjs/dotenv": "^1.4.1",
     "@types/js-cookie": "^3.0.1",
     "animated-number-vue": "^1.0.0",

--- a/frontend/shims.d.ts
+++ b/frontend/shims.d.ts
@@ -37,3 +37,8 @@ declare interface FeatureList {
     url: string | undefined;
     items: FeatureItem[];
 }
+
+declare interface PanelProps {
+    name: string;
+    title: string;
+}

--- a/frontend/store/wallet.ts
+++ b/frontend/store/wallet.ts
@@ -159,6 +159,7 @@ export const actions = {
         try {
             await depositToVAT(network, getters.getAddress, new BigNumber(amount), notifier);
             await dispatch('fetchWalletBalances');
+            await dispatch('authorizations/fetchAllowanceAmount', undefined, { root: true });
         } catch (error) {
             message.error(`Error while depositing to VAT: ${error.message}`);
         } finally {


### PR DESCRIPTION
Closes #153

Notes: 
 - This PR introduces 2px border to all antv elements to keep it consistent with our tables and panels
 - Don't forget to install frontend dependencies via `npm i`
 - Testing is done via `$nuxt.$store.dispatch("modals/setWalletModalAndFetchData", true)`

#### Both checks doesn't pass:
<img width="601" alt="Screenshot 2022-03-29 at 16 41 40" src="https://user-images.githubusercontent.com/3393626/160639610-45dc31b3-3ce4-409f-a21e-7c3193fdd72b.png">

#### Wallet have enough funds, but not enough allowance:
<img width="602" alt="Screenshot 2022-03-29 at 16 42 40" src="https://user-images.githubusercontent.com/3393626/160639624-0a660b41-efb9-4051-891c-5bbe0962f363.png">

#### Allowance amendment in progress:
<img width="600" alt="Screenshot 2022-03-30 at 09 25 28" src="https://user-images.githubusercontent.com/3393626/160775436-0d03350d-84c0-481c-beba-8eb87fd2cd83.png">

#### Both checks pass:
<img width="600" alt="Screenshot 2022-03-29 at 16 43 46" src="https://user-images.githubusercontent.com/3393626/160639634-114fc447-9261-46f3-bfab-2e7906ae2c31.png">

#### Depositing in progress:
<img width="601" alt="Screenshot 2022-03-29 at 16 43 53" src="https://user-images.githubusercontent.com/3393626/160639635-ce7c2e50-fe18-41ca-9759-dc170110df92.png">

#### Similar logic exists for the withdrawal:
<img width="603" alt="Screenshot 2022-03-29 at 21 47 01" src="https://user-images.githubusercontent.com/3393626/160694990-f248c502-dba1-4855-911c-5e80f6281f7b.png">
