### PR TITLE
reverting the commit 4454de9c9d6f752c9aa18b2b2b9506b3b37e017b

### DIFF
--- a/kubernetes/helm/templates/aws-chamber-read-secret.yaml
+++ b/kubernetes/helm/templates/aws-chamber-read-secret.yaml
@@ -2,6 +2,8 @@ apiVersion: v1
 kind: Secret
 metadata:
   name: {{ .Values.awsChamberAccountSecretName }}
+  annotations:
+    "helm.sh/hook": pre-install
 type: Opaque
 data:
   region: {{ required "AWS Region is required to perform deployment" .Values.aws.region | b64enc | quote }}


### PR DESCRIPTION
Fix for the broken CD pipeline introduced in https://github.com/sidestream-tech/unified-auctions-ui/pull/140

(this PR basically reverts https://github.com/sidestream-tech/unified-auctions-ui/commit/4454de9c9d6f752c9aa18b2b2b9506b3b37e017b#)