### PR TITLE
Collateral profit, balance and withdrawal logic

### DIFF
--- a/core/src/abis/MCD_JOIN.json
+++ b/core/src/abis/MCD_JOIN.json
@@ -1,0 +1,236 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "vat_",
+                "type": "address"
+            },
+            {
+                "internalType": "bytes32",
+                "name": "ilk_",
+                "type": "bytes32"
+            },
+            {
+                "internalType": "address",
+                "name": "gem_",
+                "type": "address"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": true,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "bytes4",
+                "name": "sig",
+                "type": "bytes4"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "usr",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "arg1",
+                "type": "bytes32"
+            },
+            {
+                "indexed": true,
+                "internalType": "bytes32",
+                "name": "arg2",
+                "type": "bytes32"
+            },
+            {
+                "indexed": false,
+                "internalType": "bytes",
+                "name": "data",
+                "type": "bytes"
+            }
+        ],
+        "name": "LogNote",
+        "type": "event"
+    },
+    {
+        "constant": false,
+        "inputs": [],
+        "name": "cage",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "dec",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "usr",
+                "type": "address"
+            }
+        ],
+        "name": "deny",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "usr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "wad",
+                "type": "uint256"
+            }
+        ],
+        "name": "exit",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "gem",
+        "outputs": [
+            {
+                "internalType": "contract GemLike",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "ilk",
+        "outputs": [
+            {
+                "internalType": "bytes32",
+                "name": "",
+                "type": "bytes32"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "usr",
+                "type": "address"
+            },
+            {
+                "internalType": "uint256",
+                "name": "wad",
+                "type": "uint256"
+            }
+        ],
+        "name": "join",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "live",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": false,
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "usr",
+                "type": "address"
+            }
+        ],
+        "name": "rely",
+        "outputs": [],
+        "payable": false,
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [],
+        "name": "vat",
+        "outputs": [
+            {
+                "internalType": "contract VatLike",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "constant": true,
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "name": "wards",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "payable": false,
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/core/src/contracts.ts
+++ b/core/src/contracts.ts
@@ -5,6 +5,7 @@ import { fetchContractAddressByNetwork } from './addresses';
 import MCD_DAI from './abis/MCD_DAI.json';
 import MCD_VAT from './abis/MCD_VAT.json';
 import MCD_JOIN_DAI from './abis/MCD_JOIN_DAI.json';
+import MCD_JOIN from './abis/MCD_JOIN.json';
 import MCD_CLIP_CALC from './abis/MCD_CLIP_CALC.json';
 import MCD_CLIP from './abis/MCD_CLIP.json';
 import WSTETH from './abis/WSTETH.json';
@@ -36,6 +37,9 @@ const getContractInterfaceByName = async function (contractName: string): Promis
     }
     if (contractName === 'MCD_JOIN_DAI') {
         return MCD_JOIN_DAI;
+    }
+    if (contractName.startsWith('MCD_JOIN_')) {
+        return MCD_JOIN;
     }
     if (contractName.startsWith('MCD_CLIP_CALC_')) {
         return MCD_CLIP_CALC;

--- a/core/src/price.ts
+++ b/core/src/price.ts
@@ -1,4 +1,4 @@
-import type { Auction } from './types';
+import type { Auction, AuctionTransaction } from './types';
 import BigNumber from './bignumber';
 import { addSeconds } from 'date-fns';
 

--- a/frontend/store/wallet.ts
+++ b/frontend/store/wallet.ts
@@ -2,7 +2,13 @@ import type { WalletBalances } from 'auctions-core/src/types';
 import { ActionContext } from 'vuex';
 import { message } from 'ant-design-vue';
 import BigNumber from 'bignumber.js';
-import { fetchWalletBalances, depositToVAT, withdrawFromVAT } from 'auctions-core/src/wallet';
+import {
+    fetchWalletBalances,
+    depositToVAT,
+    withdrawFromVAT,
+    fetchCollateralVatBalance,
+    withdrawCollateralFromVat,
+} from 'auctions-core/src/wallet';
 import getWallet, { WALLETS } from '~/lib/wallet';
 import notifier from '~/lib/notifier';
 import { getContractAddressByName } from '~/../core/src/contracts';
@@ -15,6 +21,8 @@ interface State {
     isFetchingBalances: boolean;
     isDepositingOrWithdrawing: boolean;
     tokenAddressDai: string | undefined;
+    isFetchingCollateralVatBalance: boolean;
+    collateralVatBalanceStore: Record<string, BigNumber | undefined>;
 }
 
 export const state = (): State => ({
@@ -25,6 +33,8 @@ export const state = (): State => ({
     isFetchingBalances: false,
     isDepositingOrWithdrawing: false,
     tokenAddressDai: undefined,
+    isFetchingCollateralVatBalance: false,
+    collateralVatBalanceStore: {},
 });
 
 export const getters = {
@@ -52,6 +62,12 @@ export const getters = {
     tokenAddressDai(state: State) {
         return state.tokenAddressDai;
     },
+    isFetchingCollateralVatBalance(state: State) {
+        return state.isFetchingCollateralVatBalance;
+    },
+    collateralVatBalanceStore(state: State) {
+        return state.collateralVatBalanceStore;
+    },
 };
 
 export const mutations = {
@@ -78,6 +94,15 @@ export const mutations = {
     },
     setTokenAddressDai(state: State, tokenAddressDai: string): void {
         state.tokenAddressDai = tokenAddressDai;
+    },
+    setIsFetchingCollateralVatBalance(state: State, isFetchingCollateralVatBalance: boolean): void {
+        state.isFetchingCollateralVatBalance = isFetchingCollateralVatBalance;
+    },
+    setCollateralVatBalance(
+        state: State,
+        { collateralType, balance }: { collateralType: string; balance: BigNumber }
+    ): void {
+        state.collateralVatBalanceStore[collateralType] = balance;
     },
 };
 
@@ -188,6 +213,42 @@ export const actions = {
         } catch (error) {
             await commit('setTokenAddressDai', undefined);
             message.error(`Error while fetching tokenAddressDai: ${error.message}`);
+        }
+    },
+    async fetchCollateralVatBalance(
+        { commit, getters, rootGetters }: ActionContext<State, State>,
+        collateralType: string
+    ): Promise<void> {
+        const network = rootGetters['network/getMakerNetwork'];
+        const walletAddress = getters.getAddress;
+        if (!walletAddress) {
+            commit('setCollateralVatBalance', { collateralType, balance: undefined });
+            return;
+        }
+        commit('setIsFetchingCollateralVatBalance', true);
+        try {
+            const collateralVatBalance = await fetchCollateralVatBalance(network, walletAddress, collateralType);
+            commit('setCollateralVatBalance', { collateralType, balance: collateralVatBalance });
+        } catch (error) {
+            commit('setCollateralVatBalance', { collateralType, balance: undefined });
+            message.error(`Error while fetching "${collateralType}" collateral vat balance: ${error.message}`);
+        } finally {
+            commit('setIsFetchingCollateralVatBalance', false);
+        }
+    },
+    async withdrawAllCollateralFromVat(
+        { commit, dispatch, getters, rootGetters }: ActionContext<State, State>,
+        collateralType: string
+    ): Promise<void> {
+        const network = rootGetters['network/getMakerNetwork'];
+        commit('setIsDepositingOrWithdrawing', true);
+        try {
+            await withdrawCollateralFromVat(network, getters.getAddress, collateralType, undefined, notifier);
+            await dispatch('fetchCollateralVatBalance', collateralType);
+        } catch (error) {
+            message.error(`Error while withdrawing "${collateralType}" collateral from VAT: ${error.message}`);
+        } finally {
+            commit('setIsDepositingOrWithdrawing', false);
         }
     },
 };


### PR DESCRIPTION
Closes https://github.com/sidestream-tech/unified-auctions-ui/issues/165

### Functional testing

1. Fetch and print collateral VAT balance:
```js
collateralType = 'ETH-A'; await $nuxt.$store.dispatch("wallet/fetchCollateralVatBalance", collateralType); $nuxt.$store.state.wallet.collateralVatBalanceStore[collateralType].toFixed();
```

2. Withdraw all collateral type
```js
collateralType = 'ETH-A'; await $nuxt.$store.dispatch("wallet/withdrawAllCollateralFromVat", collateralType); $nuxt.$store.state.wallet.collateralVatBalanceStore[collateralType].toFixed();
```

Note: 
- in case of ETH auctions, in the end user gets WETH, which they then have to unwrap themselves
- I'm hoping that this withdrawal step doesn't require user to approve another `MCD_JOIN_${collateralType}` contract, but we need to check that as well
