### PR TITLE
`AllowanceAmountCheckPanel` and `WalletAuthorizationCheckPanel` stories

### DIFF
--- a/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
@@ -51,23 +51,6 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
             @setAllowanceAmount="setAllowanceAmount"
         />`,
     }))
-    .add('Unlimited Allowance', () => ({
-        ...common,
-        data() {
-            return {
-                allowanceAmount: new BigNumber('99999999999999999999999999999999999999999999999999'),
-                desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
-                isLoading: false,
-            };
-        },
-        template: `
-        <AllowanceAmountCheckPanel
-            :allowance-amount="allowanceAmount"
-            :desired-amount="desiredAmount"
-            :is-loading="isLoading"
-            @setAllowanceAmount="setAllowanceAmount"
-        />`,
-    }))
     .add('Missing Allowance Amount', () => ({
         ...common,
         data() {

--- a/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
@@ -10,17 +10,28 @@ const common = {
             allowanceAmount: new BigNumber(faker.finance.amount(0, 100)),
             desiredAmount: new BigNumber(faker.finance.amount(100, 200)),
             isLoading: false,
+            disabled: false,
+            isExplanationsShown: true,
         };
     },
     methods: {
         setAllowanceAmount(amount) {
             this.isLoading = true;
             setTimeout(() => {
-                this.allowanceAmount = amount;
+                this.allowanceAmount = amount || new BigNumber(Number.MAX_VALUE);
                 this.isLoading = false;
             }, 1000);
         },
     },
+    template: `
+        <AllowanceAmountCheckPanel 
+            :allowance-amount="allowanceAmount" 
+            :desired-amount="desiredAmount"
+            :is-loading="isLoading"
+            :disabled="disabled"
+            :isExplanationsShown="isExplanationsShown"
+            @setAllowanceAmount="setAllowanceAmount" 
+        />`,
 };
 
 storiesOf('Panels/AllowanceAmountCheckPanel', module)
@@ -28,92 +39,75 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
         ...common,
         data() {
             return {
+                ...common.data(),
                 allowanceAmount: new BigNumber(faker.finance.amount(100, 200)),
                 desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
-                isLoading: false,
             };
         },
-        template: `
-        <AllowanceAmountCheckPanel 
-            :allowance-amount="allowanceAmount" 
-            :desired-amount="desiredAmount"
-            :is-loading="isLoading"
-            @setAllowanceAmount="setAllowanceAmount" 
-        />`,
     }))
     .add('Exceeds Allowance', () => ({
         ...common,
-        template: `
-        <AllowanceAmountCheckPanel
-            :allowance-amount="allowanceAmount" 
-            :desired-amount="desiredAmount"
-            :is-loading="isLoading"
-            @setAllowanceAmount="setAllowanceAmount"
-        />`,
+    }))
+    .add('Unlimited Allowance', () => ({
+        ...common,
+        data() {
+            return {
+                ...common.data(),
+                allowanceAmount: new BigNumber(Number.MAX_VALUE),
+            };
+        },
     }))
     .add('Missing Allowance Amount', () => ({
         ...common,
         data() {
             return {
+                ...common.data(),
                 allowanceAmount: undefined,
-                desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
-                isLoading: false,
             };
         },
-        template: `
-        <AllowanceAmountCheckPanel
-            :allowance-amount="allowanceAmount" 
-            :desired-amount="desiredAmount"
-            :is-loading="isLoading"
-            @setAllowanceAmount="setAllowanceAmount" 
-        />`,
     }))
     .add('Missing Desired Amount', () => ({
         ...common,
         data() {
             return {
-                allowanceAmount: new BigNumber(faker.finance.amount(100, 200)),
+                ...common.data(),
                 desiredAmount: undefined,
-                isLoading: false,
             };
         },
-        template: `
-        <AllowanceAmountCheckPanel 
-            :allowance-amount="allowanceAmount" 
-            :desired-amount="desiredAmount"
-            :is-loading="isLoading"
-            @setAllowanceAmount="setAllowanceAmount"
-        />`,
+    }))
+    .add('Desired Amount is NaN', () => ({
+        ...common,
+        data() {
+            return {
+                ...common.data(),
+                desiredAmount: new BigNumber(NaN),
+            };
+        },
     }))
     .add('Loading', () => ({
         ...common,
-        template: `
-        <AllowanceAmountCheckPanel 
-            :allowance-amount="allowanceAmount" 
-            :desired-amount="desiredAmount"
-            is-loading
-            @setAllowanceAmount="setAllowanceAmount"
-        />`,
+        data() {
+            return {
+                ...common.data(),
+                isLoading: true,
+            };
+        },
     }))
     .add('Disabled', () => ({
         ...common,
-        template: `
-        <AllowanceAmountCheckPanel 
-            :allowance-amount="allowanceAmount" 
-            :desired-amount="desiredAmount"
-            :is-loading="isLoading"
-            @setAllowanceAmount="setAllowanceAmount"
-            disabled
-        />`,
+        data() {
+            return {
+                ...common.data(),
+                disabled: true,
+            };
+        },
     }))
     .add('Expert Mode', () => ({
         ...common,
-        template: `
-        <AllowanceAmountCheckPanel 
-            :allowance-amount="allowanceAmount" 
-            :desired-amount="desiredAmount"
-            :is-loading="isLoading"
-            @setAllowanceAmount="setAllowanceAmount"
-            :is-explanations-shown="false"
-        />`,
+        data() {
+            return {
+                ...common.data(),
+                isExplanationsShown: false,
+            };
+        },
     }));

--- a/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
@@ -1,0 +1,100 @@
+import { storiesOf } from '@storybook/vue';
+import faker from 'faker';
+import BigNumber from 'bignumber.js';
+import AllowanceAmountCheckPanel from './AllowanceAmountCheckPanel';
+
+const common = {
+    components: { AllowanceAmountCheckPanel },
+    data() {
+        return {
+            allowanceAmount: new BigNumber(faker.finance.amount(0, 100)),
+            desiredAmount: new BigNumber(faker.finance.amount(100, 200)),
+        };
+    },
+};
+
+storiesOf('Panels/AllowanceAmountCheckPanel', module)
+    .add('Within Allowance', () => ({
+        ...common,
+        data() {
+            return {
+                allowanceAmount: new BigNumber(faker.finance.amount(100, 200)),
+                desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
+            };
+        },
+        template: `
+        <AllowanceAmountCheckPanel 
+            :allowanceAmount="allowanceAmount" 
+            :desiredAmount="desiredAmount"
+            @setAllowanceAmount="allowanceAmount = $event" 
+        />`,
+    }))
+    .add('Exceeds Allowance', () => ({
+        ...common,
+        template: `
+        <AllowanceAmountCheckPanel 
+            :allowanceAmount="allowanceAmount" 
+            :desiredAmount="desiredAmount"
+            @setAllowanceAmount="allowanceAmount = $event" 
+        />`,
+    }))
+    .add('Missing Allowance Amount', () => ({
+        ...common,
+        data() {
+            return {
+                allowanceAmount: undefined,
+                desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
+            };
+        },
+        template: `
+            <AllowanceAmountCheckPanel 
+                :allowanceAmount="allowanceAmount" 
+                :desiredAmount="desiredAmount"
+                @setAllowanceAmount="allowanceAmount = $event" 
+            />`,
+    }))
+    .add('Missing Desired Amount', () => ({
+        ...common,
+        data() {
+            return {
+                allowanceAmount: new BigNumber(faker.finance.amount(100, 200)),
+                desiredAmount: undefined,
+            };
+        },
+        template: `
+            <AllowanceAmountCheckPanel 
+                :allowanceAmount="allowanceAmount" 
+                :desiredAmount="desiredAmount"
+                @setAllowanceAmount="allowanceAmount = $event" 
+            />`,
+    }))
+    .add('Loading', () => ({
+        ...common,
+        template: `
+        <AllowanceAmountCheckPanel 
+            :allowanceAmount="allowanceAmount" 
+            :desiredAmount="desiredAmount"
+            @setAllowanceAmount="allowanceAmount = $event"
+            is-loading
+        />`,
+    }))
+    .add('Disabled', () => ({
+        ...common,
+        template: `
+        <AllowanceAmountCheckPanel 
+            :allowanceAmount="allowanceAmount" 
+            :desiredAmount="desiredAmount"
+            @setAllowanceAmount="allowanceAmount = $event"
+            disabled
+        />`,
+    }))
+    .add('Expert Mode', () => ({
+        ...common,
+        template: `
+        <AllowanceAmountCheckPanel 
+            :allowanceAmount="allowanceAmount" 
+            :desiredAmount="desiredAmount"
+            @setAllowanceAmount="allowanceAmount = $event"
+            :is-explanations-shown="false"
+        />`,
+    }));

--- a/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
@@ -9,7 +9,17 @@ const common = {
         return {
             allowanceAmount: new BigNumber(faker.finance.amount(0, 100)),
             desiredAmount: new BigNumber(faker.finance.amount(100, 200)),
+            isLoading: false,
         };
+    },
+    methods: {
+        setAllowanceAmount(amount) {
+            this.isLoading = true;
+            setTimeout(() => {
+                this.allowanceAmount = amount;
+                this.isLoading = false;
+            }, 1000);
+        },
     },
 };
 
@@ -24,18 +34,20 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
         },
         template: `
         <AllowanceAmountCheckPanel 
-            :allowanceAmount="allowanceAmount" 
-            :desiredAmount="desiredAmount"
-            @setAllowanceAmount="allowanceAmount = $event" 
+            :allowance-amount="allowanceAmount" 
+            :desired-amount="desiredAmount"
+            :is-loading="isLoading"
+            @setAllowanceAmount="setAllowanceAmount" 
         />`,
     }))
     .add('Exceeds Allowance', () => ({
         ...common,
         template: `
-        <AllowanceAmountCheckPanel 
-            :allowanceAmount="allowanceAmount" 
-            :desiredAmount="desiredAmount"
-            @setAllowanceAmount="allowanceAmount = $event" 
+        <AllowanceAmountCheckPanel
+            :allowance-amount="allowanceAmount" 
+            :desired-amount="desiredAmount"
+            :is-loading="isLoading"
+            @setAllowanceAmount="setAllowanceAmount"
         />`,
     }))
     .add('Missing Allowance Amount', () => ({
@@ -47,11 +59,12 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
             };
         },
         template: `
-            <AllowanceAmountCheckPanel 
-                :allowanceAmount="allowanceAmount" 
-                :desiredAmount="desiredAmount"
-                @setAllowanceAmount="allowanceAmount = $event" 
-            />`,
+        <AllowanceAmountCheckPanel
+            :allowance-amount="allowanceAmount" 
+            :desired-amount="desiredAmount"
+            :is-loading="isLoading"
+            @setAllowanceAmount="setAllowanceAmount" 
+        />`,
     }))
     .add('Missing Desired Amount', () => ({
         ...common,
@@ -62,29 +75,31 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
             };
         },
         template: `
-            <AllowanceAmountCheckPanel 
-                :allowanceAmount="allowanceAmount" 
-                :desiredAmount="desiredAmount"
-                @setAllowanceAmount="allowanceAmount = $event" 
-            />`,
+        <AllowanceAmountCheckPanel 
+            :allowance-amount="allowanceAmount" 
+            :desired-amount="desiredAmount"
+            :is-loading="isLoading"
+            @setAllowanceAmount="setAllowanceAmount"
+        />`,
     }))
     .add('Loading', () => ({
         ...common,
         template: `
         <AllowanceAmountCheckPanel 
-            :allowanceAmount="allowanceAmount" 
-            :desiredAmount="desiredAmount"
-            @setAllowanceAmount="allowanceAmount = $event"
+            :allowance-amount="allowanceAmount" 
+            :desired-amount="desiredAmount"
             is-loading
+            @setAllowanceAmount="setAllowanceAmount"
         />`,
     }))
     .add('Disabled', () => ({
         ...common,
         template: `
         <AllowanceAmountCheckPanel 
-            :allowanceAmount="allowanceAmount" 
-            :desiredAmount="desiredAmount"
-            @setAllowanceAmount="allowanceAmount = $event"
+            :allowance-amount="allowanceAmount" 
+            :desired-amount="desiredAmount"
+            :is-loading="isLoading"
+            @setAllowanceAmount="setAllowanceAmount"
             disabled
         />`,
     }))
@@ -92,9 +107,10 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
         ...common,
         template: `
         <AllowanceAmountCheckPanel 
-            :allowanceAmount="allowanceAmount" 
-            :desiredAmount="desiredAmount"
-            @setAllowanceAmount="allowanceAmount = $event"
+            :allowance-amount="allowanceAmount" 
+            :desired-amount="desiredAmount"
+            :is-loading="isLoading"
+            @setAllowanceAmount="setAllowanceAmount"
             :is-explanations-shown="false"
         />`,
     }));

--- a/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/vue';
+import { action } from '@storybook/addon-actions';
 import faker from 'faker';
 import BigNumber from 'bignumber.js';
 import AllowanceAmountCheckPanel from './AllowanceAmountCheckPanel';
@@ -11,6 +12,7 @@ const common = {
             desiredAmount: new BigNumber(faker.finance.amount(100, 200)),
             isLoading: false,
             disabled: false,
+            isCorrect: false,
             isExplanationsShown: true,
         };
     },
@@ -23,12 +25,21 @@ const common = {
             }, 1000);
         },
     },
+    watch: {
+        isCorrect: {
+            immediate: true,
+            handler(isCorrect) {
+                action('isCorrect')(isCorrect);
+            },
+        },
+    },
     template: `
         <AllowanceAmountCheckPanel 
             :allowance-amount="allowanceAmount" 
             :desired-amount="desiredAmount"
             :is-loading="isLoading"
             :disabled="disabled"
+            :is-correct.sync="isCorrect"
             :isExplanationsShown="isExplanationsShown"
             @setAllowanceAmount="setAllowanceAmount" 
         />`,

--- a/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
@@ -12,7 +12,6 @@ const common = {
             desiredAmount: new BigNumber(faker.finance.amount(100, 200)),
             isLoading: false,
             disabled: false,
-            isCorrect: false,
             isExplanationsShown: true,
         };
     },
@@ -24,101 +23,74 @@ const common = {
                 this.isLoading = false;
             }, 1000);
         },
-    },
-    watch: {
-        isCorrect: {
-            immediate: true,
-            handler(isCorrect) {
-                action('isCorrect')(isCorrect);
-            },
-        },
+        isCorrect: action('isCorrect'),
     },
     template: `
-        <AllowanceAmountCheckPanel 
-            :allowance-amount="allowanceAmount" 
-            :desired-amount="desiredAmount"
-            :is-loading="isLoading"
-            :disabled="disabled"
-            :is-correct.sync="isCorrect"
-            :isExplanationsShown="isExplanationsShown"
-            @setAllowanceAmount="setAllowanceAmount" 
+        <AllowanceAmountCheckPanel
+            v-bind="$data"
+            @setAllowanceAmount="setAllowanceAmount"
+            @update:isCorrect="isCorrect"
         />`,
 };
 
 storiesOf('Panels/AllowanceAmountCheckPanel', module)
     .add('Within Allowance', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                allowanceAmount: new BigNumber(faker.finance.amount(100, 200)),
-                desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            allowanceAmount: new BigNumber(faker.finance.amount(100, 200)),
+            desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
+        }),
     }))
     .add('Exceeds Allowance', () => ({
         ...common,
     }))
     .add('Unlimited Allowance', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                allowanceAmount: new BigNumber(Number.MAX_VALUE),
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            allowanceAmount: new BigNumber(Number.MAX_VALUE),
+        }),
     }))
     .add('Missing Allowance Amount', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                allowanceAmount: undefined,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            allowanceAmount: undefined,
+        }),
     }))
     .add('Missing Desired Amount', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                desiredAmount: undefined,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            desiredAmount: undefined,
+        }),
     }))
     .add('Desired Amount is NaN', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                desiredAmount: new BigNumber(NaN),
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            desiredAmount: new BigNumber(NaN),
+        }),
     }))
     .add('Loading', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                isLoading: true,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            isLoading: true,
+        }),
     }))
     .add('Disabled', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                disabled: true,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            disabled: true,
+        }),
     }))
     .add('Expert Mode', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                isExplanationsShown: false,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            isExplanationsShown: false,
+        }),
     }));

--- a/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.stories.js
@@ -30,6 +30,7 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
             return {
                 allowanceAmount: new BigNumber(faker.finance.amount(100, 200)),
                 desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
+                isLoading: false,
             };
         },
         template: `
@@ -50,12 +51,30 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
             @setAllowanceAmount="setAllowanceAmount"
         />`,
     }))
+    .add('Unlimited Allowance', () => ({
+        ...common,
+        data() {
+            return {
+                allowanceAmount: new BigNumber('99999999999999999999999999999999999999999999999999'),
+                desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
+                isLoading: false,
+            };
+        },
+        template: `
+        <AllowanceAmountCheckPanel
+            :allowance-amount="allowanceAmount"
+            :desired-amount="desiredAmount"
+            :is-loading="isLoading"
+            @setAllowanceAmount="setAllowanceAmount"
+        />`,
+    }))
     .add('Missing Allowance Amount', () => ({
         ...common,
         data() {
             return {
                 allowanceAmount: undefined,
                 desiredAmount: new BigNumber(faker.finance.amount(0, 100)),
+                isLoading: false,
             };
         },
         template: `
@@ -72,6 +91,7 @@ storiesOf('Panels/AllowanceAmountCheckPanel', module)
             return {
                 allowanceAmount: new BigNumber(faker.finance.amount(100, 200)),
                 desiredAmount: undefined,
+                isLoading: false,
             };
         },
         template: `

--- a/frontend/components/panels/AllowanceAmountCheckPanel.vue
+++ b/frontend/components/panels/AllowanceAmountCheckPanel.vue
@@ -24,7 +24,7 @@
         <div class="flex justify-end mt-2 gap-5">
             <BaseButton
                 class="w-full md:w-80"
-                :disabled="disabled"
+                :disabled="isDisabled"
                 :is-loading="isLoading"
                 @click="$emit('setAllowanceAmount', alwaysValidDesiredAmount)"
             >
@@ -34,7 +34,7 @@
             <BaseButton
                 class="w-full md:w-80"
                 :type="!isEnough ? 'primary' : ''"
-                :disabled="disabled || isUnlimitedAllowance"
+                :disabled="isDisabled || isUnlimitedAllowance"
                 :is-loading="isLoading"
                 @click="$emit('setAllowanceAmount')"
             >
@@ -125,6 +125,9 @@ export default Vue.extend({
                 name: 'correct',
                 title: 'The desired amount is within DAI allowance',
             };
+        },
+        isDisabled(): boolean {
+            return this.disabled || !this.allowanceAmount || this.isInvalidDesiredAmount;
         },
     },
     watch: {

--- a/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
+++ b/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
@@ -1,4 +1,5 @@
 import { storiesOf } from '@storybook/vue';
+import { action } from '@storybook/addon-actions';
 import faker from 'faker';
 import WalletAuthorizationCheckPanel from './WalletAuthorizationCheckPanel';
 
@@ -10,6 +11,7 @@ const common = {
             walletAddress: faker.finance.ethereumAddress(),
             isLoading: false,
             disabled: false,
+            isCorrect: false,
             isExplanationsShown: true,
         };
     },
@@ -22,12 +24,21 @@ const common = {
             }, 1000);
         },
     },
+    watch: {
+        isCorrect: {
+            immediate: true,
+            handler(isCorrect) {
+                action('isCorrect')(isCorrect);
+            },
+        },
+    },
     template: `
     <WalletAuthorizationCheckPanel
         :is-wallet-authorized="isWalletAuthorized"
         :wallet-address="walletAddress"
         :is-loading="isLoading"
         :disabled="disabled"
+        :is-correct.sync="isCorrect"
         :is-explanations-shown="isExplanationsShown"
         @authorizeWallet="authorize"
     />`,

--- a/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
+++ b/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
@@ -11,7 +11,6 @@ const common = {
             walletAddress: faker.finance.ethereumAddress(),
             isLoading: false,
             disabled: false,
-            isCorrect: false,
             isExplanationsShown: true,
         };
     },
@@ -23,73 +22,52 @@ const common = {
                 this.isLoading = false;
             }, 1000);
         },
-    },
-    watch: {
-        isCorrect: {
-            immediate: true,
-            handler(isCorrect) {
-                action('isCorrect')(isCorrect);
-            },
-        },
+        isCorrect: action('isCorrect'),
     },
     template: `
     <WalletAuthorizationCheckPanel
-        :is-wallet-authorized="isWalletAuthorized"
-        :wallet-address="walletAddress"
-        :is-loading="isLoading"
-        :disabled="disabled"
-        :is-correct.sync="isCorrect"
-        :is-explanations-shown="isExplanationsShown"
+        v-bind="$data"
         @authorizeWallet="authorize"
+        @update:isCorrect="isCorrect"
     />`,
 };
 
 storiesOf('Panels/WalletAuthorizationCheckPanel', module)
     .add('Authorized', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                isWalletAuthorized: true,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            isWalletAuthorized: true,
+        }),
     }))
     .add('Unauthorized', () => ({
         ...common,
     }))
     .add('Missing Wallet', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                walletAddress: undefined,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            walletAddress: undefined,
+        }),
     }))
     .add('Loading', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                isLoading: true,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            isLoading: true,
+        }),
     }))
     .add('Disabled', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                disabled: true,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            disabled: true,
+        }),
     }))
     .add('Expert Mode', () => ({
         ...common,
-        data() {
-            return {
-                ...common.data(),
-                isExplanationsShown: false,
-            };
-        },
+        data: () => ({
+            ...common.data(),
+            isExplanationsShown: false,
+        }),
     }));

--- a/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
+++ b/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
@@ -1,11 +1,100 @@
 import { storiesOf } from '@storybook/vue';
+import faker from 'faker';
 import WalletAuthorizationCheckPanel from './WalletAuthorizationCheckPanel';
 
 const common = {
     components: { WalletAuthorizationCheckPanel },
+    data() {
+        return {
+            isWalletAuthorized: false,
+            isLoading: false,
+            walletAddress: faker.finance.ethereumAddress(),
+        };
+    },
+    methods: {
+        authorize() {
+            this.isLoading = true;
+            setTimeout(() => {
+                this.isWalletAuthorized = true;
+                this.isLoading = false;
+            }, 1000);
+        },
+    },
 };
 
-storiesOf('Panels/WalletAuthorizationCheckPanel', module).add('Default', () => ({
-    ...common,
-    template: '<WalletAuthorizationCheckPanel />',
-}));
+storiesOf('Panels/WalletAuthorizationCheckPanel', module)
+    .add('Authorized', () => ({
+        ...common,
+        data() {
+            return {
+                isWalletAuthorized: true,
+                walletAddress: faker.finance.ethereumAddress(),
+            };
+        },
+        template: `
+        <WalletAuthorizationCheckPanel
+            :is-wallet-authorized="isWalletAuthorized"
+            :wallet-address="walletAddress"
+            :is-loading="isLoading"
+            @authorizeWallet="authorize"
+        />`,
+    }))
+    .add('Unauthorized', () => ({
+        ...common,
+        template: `
+        <WalletAuthorizationCheckPanel
+            :is-wallet-authorized="isWalletAuthorized"
+            :wallet-address="walletAddress"
+            :is-loading="isLoading"
+            @authorizeWallet="authorize()"
+        />`,
+    }))
+    .add('Missing Wallet', () => ({
+        ...common,
+        data() {
+            return {
+                isWalletAuthorized: false,
+                walletAddress: undefined,
+            };
+        },
+        template: `
+        <WalletAuthorizationCheckPanel
+            :is-wallet-authorized="isWalletAuthorized"
+            :wallet-address="walletAddress"
+            :is-loading="isLoading"
+            @authorizeWallet="authorize"
+        />`,
+    }))
+    .add('Loading', () => ({
+        ...common,
+        template: `
+        <WalletAuthorizationCheckPanel
+            :is-wallet-authorized="isWalletAuthorized"
+            :wallet-address="walletAddress"
+            :is-loading="isLoading"
+            @authorizeWallet="authorize"
+            is-loading
+        />`,
+    }))
+    .add('Disabled', () => ({
+        ...common,
+        template: `
+        <WalletAuthorizationCheckPanel
+            :is-wallet-authorized="isWalletAuthorized"
+            :wallet-address="walletAddress"
+            :is-loading="isLoading"
+            @authorizeWallet="authorize"
+            disabled
+        />`,
+    }))
+    .add('Expert Mode', () => ({
+        ...common,
+        template: `
+        <WalletAuthorizationCheckPanel
+            :is-wallet-authorized="isWalletAuthorized"    
+            :wallet-address="walletAddress"
+            :is-loading="isLoading"
+            @authorizeWallet="authorize"
+            :is-explanations-shown="false"
+        />`,
+    }));

--- a/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
+++ b/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
@@ -7,8 +7,10 @@ const common = {
     data() {
         return {
             isWalletAuthorized: false,
-            isLoading: false,
             walletAddress: faker.finance.ethereumAddress(),
+            isLoading: false,
+            disabled: false,
+            isExplanationsShown: true,
         };
     },
     methods: {
@@ -20,6 +22,15 @@ const common = {
             }, 1000);
         },
     },
+    template: `
+    <WalletAuthorizationCheckPanel
+        :is-wallet-authorized="isWalletAuthorized"
+        :wallet-address="walletAddress"
+        :is-loading="isLoading"
+        :disabled="disabled"
+        :is-explanations-shown="isExplanationsShown"
+        @authorizeWallet="authorize"
+    />`,
 };
 
 storiesOf('Panels/WalletAuthorizationCheckPanel', module)
@@ -27,76 +38,47 @@ storiesOf('Panels/WalletAuthorizationCheckPanel', module)
         ...common,
         data() {
             return {
+                ...common.data(),
                 isWalletAuthorized: true,
-                walletAddress: faker.finance.ethereumAddress(),
-                isLoading: false,
             };
         },
-        template: `
-        <WalletAuthorizationCheckPanel
-            :is-wallet-authorized="isWalletAuthorized"
-            :wallet-address="walletAddress"
-            :is-loading="isLoading"
-            @authorizeWallet="authorize"
-        />`,
     }))
     .add('Unauthorized', () => ({
         ...common,
-        template: `
-        <WalletAuthorizationCheckPanel
-            :is-wallet-authorized="isWalletAuthorized"
-            :wallet-address="walletAddress"
-            :is-loading="isLoading"
-            @authorizeWallet="authorize()"
-        />`,
     }))
     .add('Missing Wallet', () => ({
         ...common,
         data() {
             return {
-                isWalletAuthorized: false,
+                ...common.data(),
                 walletAddress: undefined,
-                isLoading: false,
             };
         },
-        template: `
-        <WalletAuthorizationCheckPanel
-            :is-wallet-authorized="isWalletAuthorized"
-            :wallet-address="walletAddress"
-            :is-loading="isLoading"
-            @authorizeWallet="authorize"
-        />`,
     }))
     .add('Loading', () => ({
         ...common,
-        template: `
-        <WalletAuthorizationCheckPanel
-            :is-wallet-authorized="isWalletAuthorized"
-            :wallet-address="walletAddress"
-            :is-loading="isLoading"
-            @authorizeWallet="authorize"
-            is-loading
-        />`,
+        data() {
+            return {
+                ...common.data(),
+                isLoading: true,
+            };
+        },
     }))
     .add('Disabled', () => ({
         ...common,
-        template: `
-        <WalletAuthorizationCheckPanel
-            :is-wallet-authorized="isWalletAuthorized"
-            :wallet-address="walletAddress"
-            :is-loading="isLoading"
-            @authorizeWallet="authorize"
-            disabled
-        />`,
+        data() {
+            return {
+                ...common.data(),
+                disabled: true,
+            };
+        },
     }))
     .add('Expert Mode', () => ({
         ...common,
-        template: `
-        <WalletAuthorizationCheckPanel
-            :is-wallet-authorized="isWalletAuthorized"    
-            :wallet-address="walletAddress"
-            :is-loading="isLoading"
-            @authorizeWallet="authorize"
-            :is-explanations-shown="false"
-        />`,
+        data() {
+            return {
+                ...common.data(),
+                isExplanationsShown: false,
+            };
+        },
     }));

--- a/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
+++ b/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
@@ -29,6 +29,7 @@ storiesOf('Panels/WalletAuthorizationCheckPanel', module)
             return {
                 isWalletAuthorized: true,
                 walletAddress: faker.finance.ethereumAddress(),
+                isLoading: false,
             };
         },
         template: `
@@ -55,6 +56,7 @@ storiesOf('Panels/WalletAuthorizationCheckPanel', module)
             return {
                 isWalletAuthorized: false,
                 walletAddress: undefined,
+                isLoading: false,
             };
         },
         template: `

--- a/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
+++ b/frontend/components/panels/WalletAuthorizationCheckPanel.stories.js
@@ -1,0 +1,11 @@
+import { storiesOf } from '@storybook/vue';
+import WalletAuthorizationCheckPanel from './WalletAuthorizationCheckPanel';
+
+const common = {
+    components: { WalletAuthorizationCheckPanel },
+};
+
+storiesOf('Panels/WalletAuthorizationCheckPanel', module).add('Default', () => ({
+    ...common,
+    template: '<WalletAuthorizationCheckPanel />',
+}));

--- a/frontend/components/panels/WalletAuthorizationCheckPanel.vue
+++ b/frontend/components/panels/WalletAuthorizationCheckPanel.vue
@@ -16,13 +16,13 @@
                     target="_blank"
                     >here</a
                 > </Explain
-            >. This operation should only be done once.
+            >, this operation should only be done once.
         </TextBlock>
         <div class="flex justify-end mt-2">
             <BaseButton
                 type="primary"
                 :is-loading="isLoading"
-                :disabled="disabled || isWalletAuthorized"
+                :disabled="disabled || isWalletAuthorized || !walletAddress"
                 @click="$emit('authorizeWallet')"
             >
                 <span v-if="isLoading">Authorizing...</span>


### PR DESCRIPTION
closes #174 

### `AllowanceAmountCheckPanel` stories
- Desired amount is within allowance
- Desired amount exceeds allowance
- Missing allowance amount (missing wallet)
- Missing desired amount
- Loading
- Disabled
- Expert Mode

### `WalletAuthorizationCheckPanel` stories
- Wallet is authorized
- Wallet is not authorized yet
- Wallet is missing
- Loading
- Disabled
- Expert Mode

--- 

Is the `unlimited access to DAI` functionality not added yet or why is it just setting to `undefined`?

And is the `isUnlimitedAllowance` stuff in the `AllowanceAmountCheckPanel` even necessary? Since the Panel will always be "minimized" when it's in the `correct` state and if the allowance is `unlimited`, `desired` can never be more so the panel is never in a state where it shows this information, right?