### PR TITLE
Fix gas price

### DIFF
--- a/bot-twitter/README.md
+++ b/bot-twitter/README.md
@@ -30,6 +30,7 @@ $ npm run start
 - `INFURA_PROJECT_ID`: (required) [infura](https://infura.io/) project id (can be found in: dashboard -> ethereum ->
   create new project -> settings -> keys). Note: this project can not be restricted by the origin.
 - `ETHEREUM_NETWORK`: (optional, default `kovan`) – internal network name on which the bot poll for auctions. Available
+- `MAX_PRIORITY_FEE_PER_GAS_WEI`: (optional, default can be found in core/src/gas.ts) – [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_priority_fee_per_gas` value
   options can be found in [constants/NETWORKS](../core/src/constants/NETWORKS.ts)
 - `REFETCH_INTERVAL`: (optional, default 60 seconds) – interval between auction fetching requests
 - `KEEPER_*`: (optional) set of env variables to enable keeper bot:

--- a/core/src/abis/CHAINLINK_FAST_GAS.json
+++ b/core/src/abis/CHAINLINK_FAST_GAS.json
@@ -1,0 +1,509 @@
+[
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_aggregator",
+                "type": "address"
+            },
+            {
+                "internalType": "address",
+                "name": "_accessController",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "nonpayable",
+        "type": "constructor"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "int256",
+                "name": "current",
+                "type": "int256"
+            },
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "roundId",
+                "type": "uint256"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "updatedAt",
+                "type": "uint256"
+            }
+        ],
+        "name": "AnswerUpdated",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "uint256",
+                "name": "roundId",
+                "type": "uint256"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "startedBy",
+                "type": "address"
+            },
+            {
+                "indexed": false,
+                "internalType": "uint256",
+                "name": "startedAt",
+                "type": "uint256"
+            }
+        ],
+        "name": "NewRound",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferRequested",
+        "type": "event"
+    },
+    {
+        "anonymous": false,
+        "inputs": [
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "from",
+                "type": "address"
+            },
+            {
+                "indexed": true,
+                "internalType": "address",
+                "name": "to",
+                "type": "address"
+            }
+        ],
+        "name": "OwnershipTransferred",
+        "type": "event"
+    },
+    {
+        "inputs": [],
+        "name": "acceptOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "accessController",
+        "outputs": [
+            {
+                "internalType": "contract AccessControllerInterface",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "aggregator",
+        "outputs": [
+            {
+                "internalType": "address",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_aggregator",
+                "type": "address"
+            }
+        ],
+        "name": "confirmAggregator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "decimals",
+        "outputs": [
+            {
+                "internalType": "uint8",
+                "name": "",
+                "type": "uint8"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "description",
+        "outputs": [
+            {
+                "internalType": "string",
+                "name": "",
+                "type": "string"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_roundId",
+                "type": "uint256"
+            }
+        ],
+        "name": "getAnswer",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint80",
+                "name": "_roundId",
+                "type": "uint80"
+            }
+        ],
+        "name": "getRoundData",
+        "outputs": [
+            {
+                "internalType": "uint80",
+                "name": "roundId",
+                "type": "uint80"
+            },
+            {
+                "internalType": "int256",
+                "name": "answer",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "startedAt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "updatedAt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint80",
+                "name": "answeredInRound",
+                "type": "uint80"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint256",
+                "name": "_roundId",
+                "type": "uint256"
+            }
+        ],
+        "name": "getTimestamp",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "latestAnswer",
+        "outputs": [
+            {
+                "internalType": "int256",
+                "name": "",
+                "type": "int256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "latestRound",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "latestRoundData",
+        "outputs": [
+            {
+                "internalType": "uint80",
+                "name": "roundId",
+                "type": "uint80"
+            },
+            {
+                "internalType": "int256",
+                "name": "answer",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "startedAt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "updatedAt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint80",
+                "name": "answeredInRound",
+                "type": "uint80"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "latestTimestamp",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "owner",
+        "outputs": [
+            {
+                "internalType": "address payable",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint16",
+                "name": "",
+                "type": "uint16"
+            }
+        ],
+        "name": "phaseAggregators",
+        "outputs": [
+            {
+                "internalType": "contract AggregatorV2V3Interface",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "phaseId",
+        "outputs": [
+            {
+                "internalType": "uint16",
+                "name": "",
+                "type": "uint16"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_aggregator",
+                "type": "address"
+            }
+        ],
+        "name": "proposeAggregator",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "proposedAggregator",
+        "outputs": [
+            {
+                "internalType": "contract AggregatorV2V3Interface",
+                "name": "",
+                "type": "address"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "uint80",
+                "name": "_roundId",
+                "type": "uint80"
+            }
+        ],
+        "name": "proposedGetRoundData",
+        "outputs": [
+            {
+                "internalType": "uint80",
+                "name": "roundId",
+                "type": "uint80"
+            },
+            {
+                "internalType": "int256",
+                "name": "answer",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "startedAt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "updatedAt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint80",
+                "name": "answeredInRound",
+                "type": "uint80"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "proposedLatestRoundData",
+        "outputs": [
+            {
+                "internalType": "uint80",
+                "name": "roundId",
+                "type": "uint80"
+            },
+            {
+                "internalType": "int256",
+                "name": "answer",
+                "type": "int256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "startedAt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint256",
+                "name": "updatedAt",
+                "type": "uint256"
+            },
+            {
+                "internalType": "uint80",
+                "name": "answeredInRound",
+                "type": "uint80"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_accessController",
+                "type": "address"
+            }
+        ],
+        "name": "setController",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [
+            {
+                "internalType": "address",
+                "name": "_to",
+                "type": "address"
+            }
+        ],
+        "name": "transferOwnership",
+        "outputs": [],
+        "stateMutability": "nonpayable",
+        "type": "function"
+    },
+    {
+        "inputs": [],
+        "name": "version",
+        "outputs": [
+            {
+                "internalType": "uint256",
+                "name": "",
+                "type": "uint256"
+            }
+        ],
+        "stateMutability": "view",
+        "type": "function"
+    }
+]

--- a/core/src/constants/NETWORKS.ts
+++ b/core/src/constants/NETWORKS.ts
@@ -6,7 +6,6 @@ const NETWORKS: Record<string, NetworkConfig> = {
     mainnet: {
         chainId: '0x1',
         title: 'Main',
-        gasPrice: undefined,
         url: `https://mainnet.infura.io/v3/${process.env.INFURA_PROJECT_ID}`,
         etherscanUrl: 'https://etherscan.io',
         isFork: false,

--- a/core/src/constants/NETWORKS.ts
+++ b/core/src/constants/NETWORKS.ts
@@ -30,7 +30,6 @@ const NETWORKS: Record<string, NetworkConfig> = {
     localhost: {
         chainId: '0x539',
         title: 'Localhost:8545',
-        gasPrice: 2000000000000,
         url: `http://127.0.0.1:8545`,
         etherscanUrl: '',
         isFork: true,

--- a/core/src/constants/NETWORKS.ts
+++ b/core/src/constants/NETWORKS.ts
@@ -43,6 +43,7 @@ const NETWORK_TITLES: Record<string, string | undefined> = {
     '0x3': 'ropsten',
     '0x4': 'rinkeby',
     '0x5': 'goerli',
+    '0x539': 'localhost',
 };
 
 export const getDecimalChainIdByNetworkType = function (networkType: string): number {

--- a/core/src/execute.ts
+++ b/core/src/execute.ts
@@ -24,8 +24,14 @@ const _executeTransaction = async function (
 ): Promise<string> {
     const contract = await getContract(network, contractName, true);
     const gasPrice = await getGasPrice(network);
+    const gasPriceWei = gasPrice.shiftedBy(ETH_NUMBER_OF_DIGITS);
+    const gasLimit = await contract.estimateGas[contractMethod](...contractParameters, {
+        maxPriorityFeePerGas: gasPriceWei.toFixed(0),
+        maxFeePerGas: gasPriceWei.multipliedBy(2).toFixed(0),
+    });
     const transactionPromise = contract[contractMethod](...contractParameters, {
-        gasPrice: gasPrice.shiftedBy(ETH_NUMBER_OF_DIGITS).toFixed(),
+        gasLimit,
+        maxFeePerGas: gasPriceWei.toFixed(0),
     });
     return trackTransaction(transactionPromise, notifier, canTransactionBeConfirmed(network, confirmTransaction));
 };

--- a/core/src/execute.ts
+++ b/core/src/execute.ts
@@ -2,8 +2,7 @@ import type { Notifier } from './types';
 import memoizee from 'memoizee';
 import getContract from './contracts';
 import trackTransaction from './tracker';
-import { getGasPrice } from './gas';
-import { ETH_NUMBER_OF_DIGITS } from './constants/UNITS';
+import { getGasParametersForTransaction } from './gas';
 import { getNetworkConfigByType } from './constants/NETWORKS';
 
 const canTransactionBeConfirmed = function (network: string, confirmTransaction?: boolean) {
@@ -23,15 +22,10 @@ const _executeTransaction = async function (
     confirmTransaction?: boolean
 ): Promise<string> {
     const contract = await getContract(network, contractName, true);
-    const gasPrice = await getGasPrice(network);
-    const gasPriceWei = gasPrice.shiftedBy(ETH_NUMBER_OF_DIGITS);
-    const gasLimit = await contract.estimateGas[contractMethod](...contractParameters, {
-        maxPriorityFeePerGas: gasPriceWei.toFixed(0),
-        maxFeePerGas: gasPriceWei.multipliedBy(2).toFixed(0),
-    });
+    const gasParameters = await getGasParametersForTransaction(network);
     const transactionPromise = contract[contractMethod](...contractParameters, {
-        gasLimit,
-        maxFeePerGas: gasPriceWei.toFixed(0),
+        ...gasParameters,
+        type: gasParameters.gasPrice ? undefined : 2,
     });
     return trackTransaction(transactionPromise, notifier, canTransactionBeConfirmed(network, confirmTransaction));
 };

--- a/core/src/fees.ts
+++ b/core/src/fees.ts
@@ -1,7 +1,7 @@
 import type { Auction, AuctionTransaction, TransactionFees } from './types';
 import BigNumber from './bignumber';
 import { getMarketPrice } from './calleeFunctions';
-import { getGasPrice } from './gas';
+import { getGasPriceForUI } from './gas';
 import getSigner from './signer';
 import { getCollateralAuthorizationStatus, getWalletAuthorizationStatus } from './authorizations';
 
@@ -11,7 +11,7 @@ export const convertETHtoDAI = async function (network: string, eth: BigNumber):
 };
 
 export const getApproximateTransactionFees = async function (network: string): Promise<TransactionFees> {
-    const gasPrice = await getGasPrice(network);
+    const gasPrice = await getGasPriceForUI(network);
 
     // TODO: figure out a way to properly estimate gas
     // for each transaction when no wallet is connected

--- a/core/src/fees.ts
+++ b/core/src/fees.ts
@@ -15,8 +15,8 @@ export const getApproximateTransactionFees = async function (network: string): P
 
     // TODO: figure out a way to properly estimate gas
     // for each transaction when no wallet is connected
-    const biddingTransactionFeeETH = gasPrice.multipliedBy(647053);
-    const authTransactionFeeETH = gasPrice.multipliedBy(74951);
+    const biddingTransactionFeeETH = gasPrice.multipliedBy(722651);
+    const authTransactionFeeETH = gasPrice.multipliedBy(48356);
     const restartTransactionFeeETH = gasPrice.multipliedBy(209182);
 
     return {

--- a/core/src/gas.ts
+++ b/core/src/gas.ts
@@ -9,6 +9,18 @@ import getProvider from './provider';
 
 const CHAINLINK_ORACLE_ADDRESS = '0x169e633a2d1e6c10dd91238ba11c4a708dfef37c';
 const GAS_CACHE_MS = 10 * 1000;
+const maxPriorityFeePerGas = new BigNumber(process.env.MAX_PRIORITY_FEE_PER_GAS_WEI || '1500000000').shiftedBy(
+    -ETH_NUMBER_OF_DIGITS
+);
+
+export const getBaseFeePerGas = async function (network: string): Promise<BigNumber> {
+    const provider = await getProvider(network);
+    const pendingBlock = await provider.getBlock('latest');
+    if (!pendingBlock?.baseFeePerGas?._hex) {
+        return new BigNumber(NaN);
+    }
+    return new BigNumber(pendingBlock?.baseFeePerGas?._hex).shiftedBy(-ETH_NUMBER_OF_DIGITS);
+};
 
 const getOracleGasPrice = async function (network: string): Promise<BigNumber> {
     const provider = await getProvider(network);
@@ -20,8 +32,8 @@ const getOracleGasPrice = async function (network: string): Promise<BigNumber> {
 const _getEIP1559Values = async function (network: string): Promise<GasParameters> {
     const oracleGasPrice = await getOracleGasPrice(network);
     return {
-        maxFeePerGas: oracleGasPrice.shiftedBy(ETH_NUMBER_OF_DIGITS).toFixed(0),
-        maxPriorityFeePerGas: '1500000000',
+        maxPriorityFeePerGas: maxPriorityFeePerGas.shiftedBy(ETH_NUMBER_OF_DIGITS).toFixed(0),
+        maxFeePerGas: oracleGasPrice.plus(maxPriorityFeePerGas).shiftedBy(ETH_NUMBER_OF_DIGITS).toFixed(0),
     };
 };
 

--- a/core/src/gas.ts
+++ b/core/src/gas.ts
@@ -11,7 +11,7 @@ const GAS_CACHE = 10 * 1000;
 
 const _getCurrentGasPrice = async function (): Promise<BigNumber> {
     const gasData = await fetch(API_URL).then(r => r.json());
-    const gasPriceString = ethers.utils.formatUnits(gasData[TRANSACTION_SPEED] / 10, 'gwei');
+    const gasPriceString = ethers.utils.formatUnits(gasData[TRANSACTION_SPEED], 'gwei');
     return new BigNumber(gasPriceString);
 };
 

--- a/core/src/gas.ts
+++ b/core/src/gas.ts
@@ -1,23 +1,25 @@
 import { ethers } from 'ethers';
+import memoizee from 'memoizee';
 import BigNumber from './bignumber';
 import { getNetworkConfigByType } from './constants/NETWORKS';
 import { ETH_NUMBER_OF_DIGITS } from './constants/UNITS';
-import memoizee from 'memoizee';
+import CHAINLINK_FAST_GAS_ABI from './abis/CHAINLINK_FAST_GAS.json';
+import getProvider from './provider';
 
-const API_URL = 'https://ethgasstation.info/json/ethgasAPI.json';
-const TRANSACTION_SPEED = 'fast';
+const CHAINLINK_FAST_GAS_ADDRESS = '0x169E633A2D1E6c10dD91238Ba11c4A708dfEF37C';
+const GAS_CACHE_MS = 10 * 1000;
 
-const GAS_CACHE = 10 * 1000;
-
-const _getCurrentGasPrice = async function (): Promise<BigNumber> {
-    const gasData = await fetch(API_URL).then(r => r.json());
-    const gasPriceString = ethers.utils.formatUnits(gasData[TRANSACTION_SPEED] / 10, 'gwei');
-    return new BigNumber(gasPriceString);
+const _getCurrentGasPrice = async function (network: string): Promise<BigNumber> {
+    const provider = await getProvider(network);
+    const contract = new ethers.Contract(CHAINLINK_FAST_GAS_ADDRESS, CHAINLINK_FAST_GAS_ABI, provider);
+    const gasPrice = await contract.latestAnswer();
+    return new BigNumber(gasPrice._hex).shiftedBy(-ETH_NUMBER_OF_DIGITS);
 };
 
 const getCurrentGasPrice = memoizee(_getCurrentGasPrice, {
-    maxAge: GAS_CACHE,
+    maxAge: GAS_CACHE_MS,
     promise: true,
+    length: 1,
 });
 
 export const getGasPrice = async function (network: string): Promise<BigNumber> {
@@ -26,7 +28,7 @@ export const getGasPrice = async function (network: string): Promise<BigNumber> 
         return new BigNumber(networkConfig.gasPrice).shiftedBy(-ETH_NUMBER_OF_DIGITS);
     }
     try {
-        return await getCurrentGasPrice();
+        return await getCurrentGasPrice(network);
     } catch (error) {
         throw new Error(`Gas data is not available on "${network}" network`);
     }

--- a/core/src/gas.ts
+++ b/core/src/gas.ts
@@ -11,7 +11,7 @@ const GAS_CACHE = 10 * 1000;
 
 const _getCurrentGasPrice = async function (): Promise<BigNumber> {
     const gasData = await fetch(API_URL).then(r => r.json());
-    const gasPriceString = ethers.utils.formatUnits(gasData[TRANSACTION_SPEED], 'gwei');
+    const gasPriceString = ethers.utils.formatUnits(gasData[TRANSACTION_SPEED] / 10, 'gwei');
     return new BigNumber(gasPriceString);
 };
 

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -1,5 +1,11 @@
 import BigNumber from 'bignumber.js';
 
+export declare interface GasParameters {
+    maxFeePerGas?: string;
+    maxPriorityFeePerGas?: string;
+    gasPrice?: string;
+}
+
 export declare interface AuctionInitialInfo {
     network: string;
     id: string;

--- a/frontend/README.md
+++ b/frontend/README.md
@@ -39,4 +39,5 @@ Help on both things is given in the linked resources above.
 - `PRODUCTION_DOMAIN`: (optional) Required in order to enable [plausible.io statistics](https://github.com/moritzsternemann/vue-plausible#configuration). In addition to adding it here, the domain (e.g. `auctions.makerdao.network`) should also be registered within [plausible dashboard](https://plausible.io/).
 - `CONTACT_EMAIL`: (optional) Required in order to display contact link in the footer. This email should be able to accept and manage bug reports and other contact requests.
 - `STAGING_BANNER_URL`: (optional) When set a banner will be displayed, warning the user that they are using a staging version. The text will use `STAGING_BANNER_URL` as a link to production UI.
-- `DEFAULT_ETHEREUM_NETWORK`: (optional) Can be set to change the default ethereum network. Default is mainnet.
+- `DEFAULT_ETHEREUM_NETWORK`: (optional, default `mainnet`) Can be set to change the default ethereum network
+- `MAX_PRIORITY_FEE_PER_GAS_WEI`: (optional, default can be found in core/src/gas.ts) – [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_priority_fee_per_gas` value

--- a/frontend/components/transaction/SwapTransactionTable.vue
+++ b/frontend/components/transaction/SwapTransactionTable.vue
@@ -60,7 +60,7 @@
         </div>
         <div class="flex w-full justify-between">
             <div>
-                Combined Transactions Fees
+                Maximum Transactions Fees
                 <span class="text-gray-300"
                     >(~<FormatCurrency
                         v-if="auctionTransaction.totalFeeETH"


### PR DESCRIPTION
Closes #189 
Closes https://github.com/sidestream-tech/auction-ui/issues/401

Not sure if it actually fixes the problem, but this way we compute `gasLimit` ourselves with higher gas prices.

Since the gas prices are applied differently on different networks, testing is only possible if there is an auction on the mainnet or on the hardhat fork.