### PR TITLE
Added option to whitelist collaterals

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -30,6 +30,7 @@ $ npm run start
 - `INFURA_PROJECT_ID`: (required) [infura](https://infura.io/) project id (can be found in: dashboard -> ethereum ->
   create new project -> settings -> keys). Note: this project can not be restricted by the origin.
 - `ETHEREUM_NETWORK`: (optional, default `kovan`) – internal network name on which the bot poll for auctions. Available
+- `COLLATERAL_WHITELIST`: (optional) set a list of collaterals that the bot should use. [More info](#collateral-whitelist)
 - `MAX_PRIORITY_FEE_PER_GAS_WEI`: (optional, default can be found in core/src/gas.ts) – [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_priority_fee_per_gas` value
   options can be found in [constants/NETWORKS](../core/src/constants/NETWORKS.ts)
 - `REFETCH_INTERVAL`: (optional, default 60 seconds) – interval between auction fetching requests
@@ -46,6 +47,15 @@ $ npm run start
   example: `https://auctions.makerdao.network`)
 
 Note: env variables are accessible via the `secret` command under `auction-ui/bot/${environment}`.
+
+### Collateral Whitelist
+Our bot allows users to specify which collaterals they are interested in. By default, the bot will follow the following behavior
+- Tweet about every new incoming auction
+- Bid on every auction that satisfies the minimum net profit threshold
+
+If you wish to limit the collaterals the bot accesses you can use our `COLLATERAL_WHITELIST`. In order to use this whitelist please set the environment variable `COLLATERAL_WHITELIST` to a list of the collaterals the bot should observe. Every collateral should be seperated by a comma.
+
+Example: `COLLATERAL_WHITELIST="ETH-A,ETH-C""`
 
 ## Development Setup
 

--- a/bot/README.md
+++ b/bot/README.md
@@ -30,7 +30,7 @@ $ npm run start
 - `INFURA_PROJECT_ID`: (required) [infura](https://infura.io/) project id (can be found in: dashboard -> ethereum ->
   create new project -> settings -> keys). Note: this project can not be restricted by the origin.
 - `ETHEREUM_NETWORK`: (optional, default `kovan`) – internal network name on which the bot poll for auctions. Available
-- `COLLATERAL_WHITELIST`: (optional) set a list of collaterals that the bot should use. [More info](#collateral-whitelist)
+- `WHITELISTED_COLLATERALS`: (optional) a comma-separated list of collaterals the bot will fetch. Example: `MATIC-A, UNI-A`
 - `MAX_PRIORITY_FEE_PER_GAS_WEI`: (optional, default can be found in core/src/gas.ts) – [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_priority_fee_per_gas` value
   options can be found in [constants/NETWORKS](../core/src/constants/NETWORKS.ts)
 - `REFETCH_INTERVAL`: (optional, default 60 seconds) – interval between auction fetching requests
@@ -47,15 +47,6 @@ $ npm run start
   example: `https://auctions.makerdao.network`)
 
 Note: env variables are accessible via the `secret` command under `auction-ui/bot/${environment}`.
-
-### Collateral Whitelist
-Our bot allows users to specify which collaterals they are interested in. By default, the bot will follow the following behavior
-- Tweet about every new incoming auction
-- Bid on every auction that satisfies the minimum net profit threshold
-
-If you wish to limit the collaterals the bot accesses you can use our `COLLATERAL_WHITELIST`. In order to use this whitelist please set the environment variable `COLLATERAL_WHITELIST` to a list of the collaterals the bot should observe. Every collateral should be seperated by a comma.
-
-Example: `COLLATERAL_WHITELIST="ETH-A,ETH-C""`
 
 ## Development Setup
 

--- a/bot/src/auctions.ts
+++ b/bot/src/auctions.ts
@@ -1,7 +1,6 @@
 import type { AuctionInitialInfo } from 'auctions-core/src/types';
 import { fetchAllInitialAuctions } from 'auctions-core/src/auctions';
-import { WHITELISTED_COLLATERALS } from './variables';
-import { parseCollateralWhitelist } from './whitelist';
+import { getWhitelistedCollaterals } from './whitelist';
 
 const THRESHOLD_FOR_NEW_AUCTIONS = 5 * 60 * 1000;
 const knownAuctionIds = new Set();
@@ -26,14 +25,7 @@ export const getNewAuctionsFromActiveAuctions = function (activeActions: Auction
 };
 
 export const getAllAuctions = async function (network: string): Promise<AuctionInitialInfo[]> {
-    let collateralWhitelist: undefined | string[];
-    if (WHITELISTED_COLLATERALS) {
-        collateralWhitelist = parseCollateralWhitelist(WHITELISTED_COLLATERALS);
-        console.info(`auctions: whitelist is enabled, only fetching auctions of type "${WHITELISTED_COLLATERALS}"`);
-    }
-
-    // if collateralWhitelist is undefined all auctions will be fetched
-    const auctions = await fetchAllInitialAuctions(network, collateralWhitelist);
+    const auctions = await fetchAllInitialAuctions(network, getWhitelistedCollaterals());
 
     const auctionIds = auctions.map(auction => `"${auction.id}"`).join(', ');
     console.info(`auctions: found "${auctions.length}" auctions (${auctionIds}) on "${network}" network`);

--- a/bot/src/auctions.ts
+++ b/bot/src/auctions.ts
@@ -1,6 +1,6 @@
 import type { AuctionInitialInfo } from 'auctions-core/src/types';
-import { fetchAllAuctionsFromCollateralTypes } from 'auctions-core/src/auctions';
-import { COLLATERAL_WHITELIST } from './variables';
+import { fetchAllInitialAuctions } from 'auctions-core/src/auctions';
+import { WHITELISTED_COLLATERALS } from './variables';
 import { parseCollateralWhitelist } from './whitelist';
 
 const THRESHOLD_FOR_NEW_AUCTIONS = 5 * 60 * 1000;
@@ -27,13 +27,13 @@ export const getNewAuctionsFromActiveAuctions = function (activeActions: Auction
 
 export const getAllAuctions = async function (network: string): Promise<AuctionInitialInfo[]> {
     let collateralWhitelist: undefined | string[];
-    if (COLLATERAL_WHITELIST) {
-        collateralWhitelist = parseCollateralWhitelist(COLLATERAL_WHITELIST);
-        console.info(`auctions: whitelist is enabled, only fetching auctions of type "${COLLATERAL_WHITELIST}"`);
+    if (WHITELISTED_COLLATERALS) {
+        collateralWhitelist = parseCollateralWhitelist(WHITELISTED_COLLATERALS);
+        console.info(`auctions: whitelist is enabled, only fetching auctions of type "${WHITELISTED_COLLATERALS}"`);
     }
 
     // if collateralWhitelist is undefined all auctions will be fetched
-    const auctions = await fetchAllAuctionsFromCollateralTypes(network, collateralWhitelist);
+    const auctions = await fetchAllInitialAuctions(network, collateralWhitelist);
 
     const auctionIds = auctions.map(auction => `"${auction.id}"`).join(', ');
     console.info(`auctions: found "${auctions.length}" auctions (${auctionIds}) on "${network}" network`);

--- a/bot/src/auctions.ts
+++ b/bot/src/auctions.ts
@@ -1,5 +1,5 @@
 import type { AuctionInitialInfo } from 'auctions-core/src/types';
-import { fetchAllInitialAuctions } from 'auctions-core/src/auctions';
+import { fetchAllAuctionsFromCollateralTypes } from 'auctions-core/src/auctions';
 import { COLLATERAL_WHITELIST } from './variables';
 import { parseCollateralWhitelist } from './whitelist';
 
@@ -12,17 +12,6 @@ const checkIfAuctionIsAlreadyKnown = function (auction: AuctionInitialInfo): boo
 
 const markAuctionAsKnown = function (auction: AuctionInitialInfo): void {
     knownAuctionIds.add(auction.id);
-};
-
-const checkIfAuctionCollateralIsInWhitelist = function (
-    auction: AuctionInitialInfo,
-    whitelist: string[] | undefined
-): boolean {
-    // if whitelist is disabled all auctions should be used
-    if (!whitelist) {
-        return true;
-    }
-    return whitelist.includes(auction.collateralType);
 };
 
 export const getNewAuctionsFromActiveAuctions = function (activeActions: AuctionInitialInfo[]): AuctionInitialInfo[] {
@@ -43,13 +32,10 @@ export const getAllAuctions = async function (network: string): Promise<AuctionI
         console.info(`auctions: whitelist is enabled, only fetching auctions of type "${COLLATERAL_WHITELIST}"`);
     }
 
-    const auctions = await fetchAllInitialAuctions(network);
-    const filteredAuctions = auctions.filter(auction =>
-        checkIfAuctionCollateralIsInWhitelist(auction, collateralWhitelist)
-    );
-    const auctionIds = filteredAuctions.map(auction => `"${auction.id}"`).join(', ');
-    console.info(
-        `auctions: found "${filteredAuctions.length}/${auctions.length}" auctions (${auctionIds}) on "${network}" network`
-    );
-    return filteredAuctions;
+    // if collateralWhitelist is undefined all auctions will be fetched
+    const auctions = await fetchAllAuctionsFromCollateralTypes(network, collateralWhitelist);
+
+    const auctionIds = auctions.map(auction => `"${auction.id}"`).join(', ');
+    console.info(`auctions: found "${auctions.length}" auctions (${auctionIds}) on "${network}" network`);
+    return auctions;
 };

--- a/bot/src/auctions.ts
+++ b/bot/src/auctions.ts
@@ -40,11 +40,16 @@ export const getAllAuctions = async function (network: string): Promise<AuctionI
     let collateralWhitelist: undefined | string[];
     if (COLLATERAL_WHITELIST) {
         collateralWhitelist = parseCollateralWhitelist(COLLATERAL_WHITELIST);
-        console.info(`auctions: whitelist is enabled, only fetching auctions from "${COLLATERAL_WHITELIST}"`);
+        console.info(`auctions: whitelist is enabled, only fetching auctions of type "${COLLATERAL_WHITELIST}"`);
     }
 
     const auctions = await fetchAllInitialAuctions(network);
-    const auctionIds = auctions.map(auction => `"${auction.id}"`).join(', ');
-    console.info(`auctions: found "${auctions.length}" auctions (${auctionIds}) on "${network}" network`);
-    return auctions.filter(auction => checkIfAuctionCollateralIsInWhitelist(auction, collateralWhitelist));
+    const filteredAuctions = auctions.filter(auction =>
+        checkIfAuctionCollateralIsInWhitelist(auction, collateralWhitelist)
+    );
+    const auctionIds = filteredAuctions.map(auction => `"${auction.id}"`).join(', ');
+    console.info(
+        `auctions: found "${filteredAuctions.length}/${auctions.length}" auctions (${auctionIds}) on "${network}" network`
+    );
+    return filteredAuctions;
 };

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -28,7 +28,7 @@ const loop = async function (): Promise<void> {
 const start = async function (): Promise<void> {
     await delay(SETUP_DELAY);
     getNetworkConfigByType(ETHEREUM_NETWORK);
-    await setupWhitelist();
+    setupWhitelist();
     await setupTwitter();
     await setupKeeper();
     loop();

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -28,7 +28,7 @@ const loop = async function (): Promise<void> {
 const start = async function (): Promise<void> {
     await delay(SETUP_DELAY);
     getNetworkConfigByType(ETHEREUM_NETWORK);
-    setupWhitelist();
+    await setupWhitelist();
     await setupTwitter();
     await setupKeeper();
     loop();

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -5,6 +5,7 @@ import notify from './notify';
 import participate, { setupKeeper } from './keeper';
 import { ETHEREUM_NETWORK } from './variables';
 import { setupTwitter } from './twitter';
+import { setupWhitelist } from './whitelist';
 
 const DEFAULT_REFETCH_INTERVAL = 60 * 1000;
 const SETUP_DELAY = 3 * 1000;
@@ -27,6 +28,7 @@ const loop = async function (): Promise<void> {
 const start = async function (): Promise<void> {
     await delay(SETUP_DELAY);
     getNetworkConfigByType(ETHEREUM_NETWORK);
+    setupWhitelist();
     await setupTwitter();
     await setupKeeper();
     loop();

--- a/bot/src/variables.ts
+++ b/bot/src/variables.ts
@@ -1,4 +1,4 @@
 export const ETHEREUM_NETWORK = process.env.ETHEREUM_NETWORK || 'kovan';
 export const KEEPER_MINIMUM_NET_PROFIT_DAI = parseInt(process.env.KEEPER_MINIMUM_NET_PROFIT_DAI || '');
 export const KEEPER_WALLET_PRIVATE_KEY = process.env.KEEPER_WALLET_PRIVATE_KEY;
-export const WHITELISTED_COLLATERALS = process.env.WHITELISTED_COLLATERALS || false;
+export const WHITELISTED_COLLATERALS = process.env.WHITELISTED_COLLATERALS;

--- a/bot/src/variables.ts
+++ b/bot/src/variables.ts
@@ -1,3 +1,4 @@
 export const ETHEREUM_NETWORK = process.env.ETHEREUM_NETWORK || 'kovan';
 export const KEEPER_MINIMUM_NET_PROFIT_DAI = parseInt(process.env.KEEPER_MINIMUM_NET_PROFIT_DAI || '');
 export const KEEPER_WALLET_PRIVATE_KEY = process.env.KEEPER_WALLET_PRIVATE_KEY;
+export const COLLATERAL_WHITELIST = process.env.COLLATERAL_WHITELIST || false;

--- a/bot/src/variables.ts
+++ b/bot/src/variables.ts
@@ -1,4 +1,4 @@
 export const ETHEREUM_NETWORK = process.env.ETHEREUM_NETWORK || 'kovan';
 export const KEEPER_MINIMUM_NET_PROFIT_DAI = parseInt(process.env.KEEPER_MINIMUM_NET_PROFIT_DAI || '');
 export const KEEPER_WALLET_PRIVATE_KEY = process.env.KEEPER_WALLET_PRIVATE_KEY;
-export const COLLATERAL_WHITELIST = process.env.COLLATERAL_WHITELIST || false;
+export const COLLATERAL_WHITELIST = process.env.WHITELISTED_COLLATERALS || false;

--- a/bot/src/variables.ts
+++ b/bot/src/variables.ts
@@ -1,4 +1,4 @@
 export const ETHEREUM_NETWORK = process.env.ETHEREUM_NETWORK || 'kovan';
 export const KEEPER_MINIMUM_NET_PROFIT_DAI = parseInt(process.env.KEEPER_MINIMUM_NET_PROFIT_DAI || '');
 export const KEEPER_WALLET_PRIVATE_KEY = process.env.KEEPER_WALLET_PRIVATE_KEY;
-export const COLLATERAL_WHITELIST = process.env.WHITELISTED_COLLATERALS || false;
+export const WHITELISTED_COLLATERALS = process.env.WHITELISTED_COLLATERALS || false;

--- a/bot/src/whitelist.ts
+++ b/bot/src/whitelist.ts
@@ -1,5 +1,5 @@
 import { getCollateralConfigByType } from 'auctions-core/src/constants/COLLATERALS';
-import { COLLATERAL_WHITELIST } from './variables';
+import { WHITELISTED_COLLATERALS } from './variables';
 
 const validateWhitelist = function (whitelist: string[]) {
     whitelist.forEach(collateralType => {
@@ -12,8 +12,8 @@ export const parseCollateralWhitelist = function (whitelist: string): string[] {
 };
 
 export const setupWhitelist = function (): void {
-    if (COLLATERAL_WHITELIST) {
-        const parsedWhitelist = parseCollateralWhitelist(COLLATERAL_WHITELIST);
+    if (WHITELISTED_COLLATERALS) {
+        const parsedWhitelist = parseCollateralWhitelist(WHITELISTED_COLLATERALS);
         validateWhitelist(parsedWhitelist);
     } else {
         console.warn(`collateral whitelisting: skipping setup due to missing WHITELISTED_COLLATERALS`);

--- a/bot/src/whitelist.ts
+++ b/bot/src/whitelist.ts
@@ -3,16 +3,20 @@ import { WHITELISTED_COLLATERALS } from './variables';
 
 const validateWhitelist = function (whitelist: string[]): Promise<void> {
     return new Promise((resolve, reject) => {
-        const errors: string[] = [];
+        const unsupportedCollateralTypes: string[] = [];
         whitelist.forEach(collateralType => {
             try {
                 getCollateralConfigByType(collateralType);
             } catch (error) {
-                errors.push(collateralType);
+                unsupportedCollateralTypes.push(collateralType);
             }
         });
-        if (errors.length > 0) {
-            reject(new Error(`collateral whitelisting: no collaterals found for "${errors.toString()}"`));
+        if (unsupportedCollateralTypes.length > 0) {
+            reject(
+                new Error(
+                    `collateral whitelisting: no collaterals found for "${unsupportedCollateralTypes.toString()}"`
+                )
+            );
         }
         resolve();
     });

--- a/bot/src/whitelist.ts
+++ b/bot/src/whitelist.ts
@@ -1,25 +1,20 @@
 import { getCollateralConfigByType } from 'auctions-core/src/constants/COLLATERALS';
 import { WHITELISTED_COLLATERALS } from './variables';
 
-const validateWhitelist = function (whitelist: string[]): Promise<void> {
-    return new Promise((resolve, reject) => {
-        const unsupportedCollateralTypes: string[] = [];
-        whitelist.forEach(collateralType => {
-            try {
-                getCollateralConfigByType(collateralType);
-            } catch (error) {
-                unsupportedCollateralTypes.push(collateralType);
-            }
-        });
-        if (unsupportedCollateralTypes.length > 0) {
-            reject(
-                new Error(
-                    `collateral whitelisting: no collaterals found for "${unsupportedCollateralTypes.toString()}"`
-                )
-            );
+const validateWhitelist = function (whitelist: string[]) {
+    const unsupportedCollateralTypes: string[] = [];
+    whitelist.forEach(collateralType => {
+        try {
+            getCollateralConfigByType(collateralType);
+        } catch (error) {
+            unsupportedCollateralTypes.push(collateralType);
         }
-        resolve();
     });
+    if (unsupportedCollateralTypes.length > 0) {
+        throw new Error(
+            `collateral whitelisting: no collaterals found for "${unsupportedCollateralTypes.toString()}"`
+        );
+    }
 };
 
 export const parseCollateralWhitelist = function (whitelist: string): string[] {
@@ -33,10 +28,10 @@ export const getWhitelistedCollaterals = function () {
     return undefined;
 };
 
-export const setupWhitelist = async function (): Promise<void> {
+export const setupWhitelist = function () {
     if (WHITELISTED_COLLATERALS) {
         const parsedWhitelist = parseCollateralWhitelist(WHITELISTED_COLLATERALS);
-        await validateWhitelist(parsedWhitelist);
+        validateWhitelist(parsedWhitelist);
         console.info(
             `collateral whitelisting: whitelist is enabled, only fetching auctions of type "${WHITELISTED_COLLATERALS}"`
         );

--- a/bot/src/whitelist.ts
+++ b/bot/src/whitelist.ts
@@ -1,0 +1,25 @@
+import COLLATERALS from 'auctions-core/src/constants/COLLATERALS';
+import { COLLATERAL_WHITELIST } from './variables';
+
+const validateWhitelist = function (whitelist: string[]) {
+    whitelist.map(collateralType => {
+        if (!COLLATERALS[collateralType]) {
+            throw new Error(`whitelist: incorrect collateral type found "${collateralType}"`);
+        }
+        return true;
+    });
+};
+
+export const parseCollateralWhitelist = function (whitelist: string): string[] {
+    const whitelistNoSpaces = whitelist.replace(/\s/g, '');
+    return whitelistNoSpaces.split(',');
+};
+
+export const setupWhitelist = function (): void {
+    if (COLLATERAL_WHITELIST) {
+        const parsedWhitelist = parseCollateralWhitelist(COLLATERAL_WHITELIST);
+        validateWhitelist(parsedWhitelist);
+    } else {
+        console.warn(`whitelist: skipping setup due to missing collateral whitelist`);
+    }
+};

--- a/bot/src/whitelist.ts
+++ b/bot/src/whitelist.ts
@@ -1,18 +1,14 @@
-import COLLATERALS from 'auctions-core/src/constants/COLLATERALS';
+import { getCollateralConfigByType } from 'auctions-core/src/constants/COLLATERALS';
 import { COLLATERAL_WHITELIST } from './variables';
 
 const validateWhitelist = function (whitelist: string[]) {
-    whitelist.map(collateralType => {
-        if (!COLLATERALS[collateralType]) {
-            throw new Error(`whitelist: incorrect collateral type found "${collateralType}"`);
-        }
-        return true;
+    whitelist.forEach(collateralType => {
+        getCollateralConfigByType(collateralType);
     });
 };
 
 export const parseCollateralWhitelist = function (whitelist: string): string[] {
-    const whitelistNoSpaces = whitelist.replace(/\s/g, '');
-    return whitelistNoSpaces.split(',');
+    return whitelist.split(',').map(item => item.trim());
 };
 
 export const setupWhitelist = function (): void {
@@ -20,6 +16,6 @@ export const setupWhitelist = function (): void {
         const parsedWhitelist = parseCollateralWhitelist(COLLATERAL_WHITELIST);
         validateWhitelist(parsedWhitelist);
     } else {
-        console.warn(`whitelist: skipping setup due to missing collateral whitelist`);
+        console.warn(`collateral whitelisting: skipping setup due to missing WHITELISTED_COLLATERALS`);
     }
 };

--- a/bot/src/whitelist.ts
+++ b/bot/src/whitelist.ts
@@ -1,9 +1,20 @@
 import { getCollateralConfigByType } from 'auctions-core/src/constants/COLLATERALS';
 import { WHITELISTED_COLLATERALS } from './variables';
 
-const validateWhitelist = function (whitelist: string[]) {
-    whitelist.forEach(collateralType => {
-        getCollateralConfigByType(collateralType);
+const validateWhitelist = function (whitelist: string[]): Promise<void> {
+    return new Promise((resolve, reject) => {
+        const errors: string[] = [];
+        whitelist.forEach(collateralType => {
+            try {
+                getCollateralConfigByType(collateralType);
+            } catch (error) {
+                errors.push(collateralType);
+            }
+        });
+        if (errors.length > 0) {
+            reject(new Error(`collateral whitelisting: no collaterals found for "${errors.toString()}"`));
+        }
+        resolve();
     });
 };
 
@@ -11,10 +22,20 @@ export const parseCollateralWhitelist = function (whitelist: string): string[] {
     return whitelist.split(',').map(item => item.trim());
 };
 
-export const setupWhitelist = function (): void {
+export const getWhitelistedCollaterals = function () {
+    if (WHITELISTED_COLLATERALS) {
+        return parseCollateralWhitelist(WHITELISTED_COLLATERALS);
+    }
+    return undefined;
+};
+
+export const setupWhitelist = async function (): Promise<void> {
     if (WHITELISTED_COLLATERALS) {
         const parsedWhitelist = parseCollateralWhitelist(WHITELISTED_COLLATERALS);
-        validateWhitelist(parsedWhitelist);
+        await validateWhitelist(parsedWhitelist);
+        console.info(
+            `collateral whitelisting: whitelist is enabled, only fetching auctions of type "${WHITELISTED_COLLATERALS}"`
+        );
     } else {
         console.warn(`collateral whitelisting: skipping setup due to missing WHITELISTED_COLLATERALS`);
     }

--- a/core/src/auctions.ts
+++ b/core/src/auctions.ts
@@ -20,7 +20,6 @@ import { enrichAuctionWithTransactionFees, getApproximateTransactionFees } from 
 import parseAuctionId from './helpers/parseAuctionId';
 import { EventFilter } from 'ethers';
 import getNetworkDate, { fetchDateByBlockNumber } from './date';
-import { getCollateralConfigByType } from './constants/COLLATERALS';
 
 const enrichAuctionWithActualNumbers = async function (
     network: string,
@@ -102,29 +101,13 @@ export const enrichAuctionWithPriceDropAndMarketValue = async function (
     return await enrichAuctionWithMarketValues(enrichedAuctionWithNewPriceDrop, network);
 };
 
-export const fetchAllInitialAuctions = async function (network: string): Promise<AuctionInitialInfo[]> {
-    const collateralTypes = await getSupportedCollateralTypes(network);
-    const auctionGroupsPromises = collateralTypes.map((collateralType: string) => {
-        return fetchAuctionsByCollateralType(network, collateralType);
-    });
-    const auctionGroups = await Promise.all(auctionGroupsPromises);
-    return auctionGroups.flat();
-};
-
-export const fetchAllAuctionsFromCollateralTypes = async function (
+export const fetchAllInitialAuctions = async function (
     network: string,
-    collateralTypes: string[] | undefined
+    collateralTypes?: string[]
 ): Promise<AuctionInitialInfo[]> {
-    // If no collateralTypes list is given return all auctions from all collateralTypes
     if (!collateralTypes) {
-        return await fetchAllInitialAuctions(network);
+        collateralTypes = await getSupportedCollateralTypes(network);
     }
-
-    // Map through given collateral types and validate that our UI supports them
-    collateralTypes.forEach(collateralType => {
-        getCollateralConfigByType(collateralType);
-    });
-
     const auctionGroupsPromises = collateralTypes.map((collateralType: string) => {
         return fetchAuctionsByCollateralType(network, collateralType);
     });


### PR DESCRIPTION
closes #206 

**Correctly setup:**
![Screenshot 2022-04-14 at 06 36 07](https://user-images.githubusercontent.com/30908158/163314591-ff1df908-6463-4b65-b698-8485154d0535.png)

The `1/7` in the message is structured as follows `WHITELISTED_AUCTIONS/ALL_AUCTIONS`. I thought this would be better to avoid confusion in case you forgot to deactivate your whitelist and you are wondering why there are so few auctions.

**Error in whitelist (shown on startup):**
![Screenshot 2022-04-14 at 06 36 33](https://user-images.githubusercontent.com/30908158/163314836-78817100-ce7e-4bcf-8c79-dbba5ab15e5e.png)

**No whitelist set:**
![Screenshot 2022-04-14 at 06 36 53](https://user-images.githubusercontent.com/30908158/163314855-e10927eb-a4d2-4ee7-951c-8706bbc87ae8.png)

_I was wondering, would it make sense to also include a `blacklist`? I was thinking, what if someone only wanted to exclude say two collaterals. They would have to make a very long list of every collateral except for the two they don't want._
