### PR TITLE
Updated Twitter Message

### DIFF
--- a/bot/src/notify.ts
+++ b/bot/src/notify.ts
@@ -3,7 +3,7 @@ import { sendNotification } from './twitter';
 
 const generateNotificationText = function (auction: AuctionInitialInfo): string {
     const url = `${process.env.FRONTEND_ORIGIN}/collateral/?network=${auction.network}&auction=${auction.id}`;
-    return `Collateral auction with ${auction.collateralAmount.toFixed(2)} ${
+    return `Collateral auction with ${auction.collateralAmount.toFixed(2)} $${
         auction.collateralSymbol
     } just started. Follow the link to participate: ${url}`;
 };


### PR DESCRIPTION
closes #87 

I don't know if this PR/Issue are really needed, as I took it from the backlog. But as it was such a simple change I decided to take care of it. 

This PR just changes the Tweet message to include a `$` before the currency type. 