### PR TITLE
Fix bid with NaN

### DIFF
--- a/frontend/components/transaction/BidTransaction.vue
+++ b/frontend/components/transaction/BidTransaction.vue
@@ -64,7 +64,8 @@
                 !isWalletConnected ||
                 !isEnoughDeposited ||
                 !isWalletAuthorizedCorrect ||
-                !isCollateralAuthorized
+                !isCollateralAuthorized ||
+                isAmountToReceiveUknown
             "
             :is-loading="isExecuting"
             :is-explanations-shown="isExplanationsShown"
@@ -182,6 +183,9 @@ export default Vue.extend({
                 this.auctionTransaction.approximateUnitPrice,
                 this.auctionTransaction
             );
+        },
+        isAmountToReceiveUknown(): boolean {
+            return this.amountToReceive?.isNaN();
         },
     },
 });


### PR DESCRIPTION
Fixes a recently discovered edge case with `Bid with DAI` transaction by disabling a button. Later we would need to add another panel explaining [`Clipper/no-partial-purchase` error](https://github.com/makerdao/dss/blob/60690042965500992490f695cf259256cc94c140/src/clip.sol#L374)

<img width="680" alt="Screenshot 2022-04-14 at 17 05 23" src="https://user-images.githubusercontent.com/3393626/163419075-0c44a55b-dcbd-4bd3-bf3a-de4ca138cb57.png">
