### PR TITLE
Hide secondsTillNextPriceDrop if not available

### DIFF
--- a/frontend/components/utils/PriceDropAnimation.vue
+++ b/frontend/components/utils/PriceDropAnimation.vue
@@ -1,5 +1,5 @@
 <template>
-    <span v-if="auction.isActive && !auction.isFinished">
+    <span v-if="auction.isActive && !auction.isFinished && auction.secondsTillNextPriceDrop">
         <Popover :placement="placement">
             <template slot="content">
                 <div class="text-center">


### PR DESCRIPTION
Contributes to #215 

This PR removes tooltip with secondsTillNextPriceDrop if the data is not available:

Before:
<img width="246" alt="Screenshot 2022-04-19 at 18 04 04" src="https://user-images.githubusercontent.com/3393626/164047069-515cafde-79b6-4907-8ad3-dd13fb83039a.png">

After
<img width="154" alt="Screenshot 2022-04-19 at 18 05 06" src="https://user-images.githubusercontent.com/3393626/164047152-4eb6c10a-c6c2-42fe-8a4e-98ea048b9bf4.png">
: