### PR TITLE
Improve keeper by running auctions synchronously

### DIFF
--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -18,7 +18,7 @@ const loop = async function (): Promise<void> {
         }
         const newAuctions = getNewAuctionsFromActiveAuctions(activeAuctions);
         newAuctions.map(notify);
-        await participate(activeAuctions);
+        participate(activeAuctions);
     } catch (error) {
         console.error('loop error:', error);
     }

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -18,7 +18,7 @@ const loop = async function (): Promise<void> {
         }
         const newAuctions = getNewAuctionsFromActiveAuctions(activeAuctions);
         newAuctions.map(notify);
-        activeAuctions.map(participate);
+        await participate(activeAuctions);
     } catch (error) {
         console.error('loop error:', error);
     }

--- a/bot/src/keeper.ts
+++ b/bot/src/keeper.ts
@@ -131,7 +131,7 @@ const checkAndParticipateIfPossible = async function (auction: AuctionInitialInf
     console.info(`keeper: auction "${auctionTransaction.id}" was succesfully executed via "${bidHash}" transaction`);
 };
 
-const participate = async function (auction: AuctionInitialInfo) {
+const participateInAuction = async function (auction: AuctionInitialInfo) {
     // check if this auction is currently executed to avoid double execution
     if (currentlyExecutedAuctions.has(auction.id)) {
         return;
@@ -147,6 +147,12 @@ const participate = async function (auction: AuctionInitialInfo) {
 
     // clear pool of currently executed auctions
     currentlyExecutedAuctions.delete(auction.id);
+};
+
+export const participate = async function (auctions: AuctionInitialInfo[]) {
+    for (let i = 0; i < auctions.length; i += 1) {
+        await participateInAuction(auctions[i]);
+    }
 };
 
 export default participate;

--- a/bot/src/keeper.ts
+++ b/bot/src/keeper.ts
@@ -150,8 +150,8 @@ const participateInAuction = async function (auction: AuctionInitialInfo) {
 };
 
 export const participate = async function (auctions: AuctionInitialInfo[]) {
-    for (let i = 0; i < auctions.length; i += 1) {
-        await participateInAuction(auctions[i]);
+    for (const auction of auctions) {
+        await participateInAuction(auction);
     }
 };
 


### PR DESCRIPTION
closes #220 

The keeper bot now waits until the last auction was executed before starting to execute the next one:

![Screenshot 2022-04-21 at 16 14 33](https://user-images.githubusercontent.com/30908158/164478136-3f840af5-698b-41f6-b393-6bc5dd64fb72.png)

The `console.log` that an Auction is being started to participate in only runs after the last auction returned a result. 

Tested using: 

- HardHat
- Goerli