### PR TITLE
Updated step to profitability calculation

### DIFF
--- a/core/src/price.ts
+++ b/core/src/price.ts
@@ -110,14 +110,12 @@ export const calculateTransactionGrossProfitDate = function (auction: Auction, c
         return undefined;
     }
 
-    let steps = 0;
-    let currentValue = new BigNumber(auction.approximateUnitPrice);
+    const stepNumber = Math.ceil(
+        Math.log(auction.marketUnitPrice.dividedBy(auction.approximateUnitPrice).toNumber()) /
+            Math.log(auction.priceDropRatio.toNumber())
+    );
 
-    while (currentValue.isGreaterThan(auction.marketUnitPrice)) {
-        steps += 1;
-        currentValue = currentValue.multipliedBy(auction.priceDropRatio);
-    }
     const secondsSinceLastPriceDrop = auction.secondsBetweenPriceDrops - auction.secondsTillNextPriceDrop;
-    const secondsTillProfitable = auction.secondsBetweenPriceDrops * steps - secondsSinceLastPriceDrop;
+    const secondsTillProfitable = auction.secondsBetweenPriceDrops * stepNumber - secondsSinceLastPriceDrop;
     return addSeconds(currentDate, secondsTillProfitable);
 };


### PR DESCRIPTION
Closes #221

I managed to implement the new algorithm. After implementing it, I ran both calculation methods at the same time and made sure that all the results lined up:

![Screenshot 2022-05-06 at 00 59 25](https://user-images.githubusercontent.com/30908158/167041638-5b2146a8-12bb-4479-86e4-65da7d2c1eb9.png)

Afterwards, I ran the chrome performance tool on both algorithms to determine which one is more performant. The results are shown below:

**Old Algorithm**:
![Screenshot 2022-05-06 at 01 08 44](https://user-images.githubusercontent.com/30908158/167041742-af79239b-0761-4189-b6c0-ef1b56b06dd0.png)

**New Algorithm**:
![Screenshot 2022-05-06 at 01 08 38](https://user-images.githubusercontent.com/30908158/167041761-b6320a9d-57f6-418f-961e-325315e41231.png)

From what I can see the new algorithm and therefore this PR, perform slightly better than the old looping version.

----

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
