### PR TITLE
Do not refetch all auctions, when one is opened

### DIFF
--- a/core/src/auctions.ts
+++ b/core/src/auctions.ts
@@ -1,6 +1,10 @@
 import type { Auction, AuctionInitialInfo, AuctionTransaction, Notifier, TakeEvent } from './types';
 import BigNumber from './bignumber';
-import fetchAuctionsByCollateralType, { fetchAuctionStatus, fetchMinimumBidDai } from './fetch';
+import fetchAuctionsByCollateralType, {
+    fetchAuctionByCollateralTypeAndAuctionIndex,
+    fetchAuctionStatus,
+    fetchMinimumBidDai,
+} from './fetch';
 import { getCalleeData, getMarketPrice } from './calleeFunctions';
 import { fetchCalcParametersByCollateralType } from './params';
 import executeTransaction from './execute';
@@ -106,6 +110,15 @@ export const enrichAuctionWithPriceDropAndMarketValue = async function (
 ): Promise<Auction> {
     const enrichedAuctionWithNewPriceDrop = await enrichAuctionWithPriceDrop(auction);
     return await enrichAuctionWithMarketValues(enrichedAuctionWithNewPriceDrop, network);
+};
+
+export const fetchSingleAuctionById = async function (
+    network: string,
+    auctionId: string
+): Promise<AuctionTransaction> {
+    const { collateralType, index } = parseAuctionId(auctionId);
+    const auction = await fetchAuctionByCollateralTypeAndAuctionIndex(network, collateralType, index);
+    return enrichAuction(network, auction);
 };
 
 export const fetchAllInitialAuctions = async function (

--- a/core/src/fetch.ts
+++ b/core/src/fetch.ts
@@ -55,7 +55,7 @@ export const fetchAuctionStatus = async function (
     };
 };
 
-const fetchAuctionByCollateralTypeAndAuctionIndex = async function (
+export const fetchAuctionByCollateralTypeAndAuctionIndex = async function (
     network: string,
     collateralType: string,
     auctionIndex: number

--- a/frontend/components/Auction.vue
+++ b/frontend/components/Auction.vue
@@ -340,14 +340,14 @@ export default Vue.extend({
     },
     computed: {
         auctionError(): { error: string; showBanner: boolean } | null {
-            if (!this.areAuctionsFetching && !this.areTakeEventsFetching && !this.auction && !this.takeEvents) {
-                return {
-                    error: 'This auction was not found',
-                    showBanner: true,
-                };
-            } else if (this.error) {
+            if (this.error) {
                 return {
                     error: this.error,
+                    showBanner: true,
+                };
+            } else if (!this.areAuctionsFetching && !this.areTakeEventsFetching && !this.auction && !this.takeEvents) {
+                return {
+                    error: 'This auction was not found',
                     showBanner: true,
                 };
             } else if (this.auction?.isFinished || (!this.auction && this.takeEvents)) {
@@ -388,7 +388,7 @@ export default Vue.extend({
             },
         },
         areAuctionsFetching(areAuctionsFetching) {
-            if (!areAuctionsFetching && !this.auction) {
+            if (!areAuctionsFetching && !this.auction && !this.error) {
                 this.$emit('fetchTakeEventsFromAuction', this.auctionId);
             }
         },

--- a/frontend/components/MainFlow.vue
+++ b/frontend/components/MainFlow.vue
@@ -30,6 +30,7 @@
                         :auction-id="selectedAuctionId"
                         :are-auctions-fetching="areAuctionsFetching || isSelectedAuctionFetching"
                         :are-take-events-fetching="areTakeEventsFetching"
+                        :error="selectedAuctionError"
                         @restart="$emit('restart', $event)"
                         @connect="$emit('connect')"
                         @disconnect="$emit('disconnect')"
@@ -124,6 +125,10 @@ export default Vue.extend({
             type: String,
             default: null,
         },
+        auctionErrors: {
+            type: Object as Vue.PropType<string, string>,
+            default: () => ({}),
+        },
         selectedAuctionId: {
             type: String,
             default: null,
@@ -188,6 +193,9 @@ export default Vue.extend({
     computed: {
         selectedAuction(): AuctionTransaction | null {
             return this.auctions.find(auctionTransaction => auctionTransaction.id === this.selectedAuctionId) || null;
+        },
+        selectedAuctionError(): string | null {
+            return this.auctionErrors[this.selectedAuctionId] || null;
         },
         selectedTakeEvents(): TakeEvent[] | null {
             if (this.selectedAuction === null && this.takeEventStorage) {

--- a/frontend/components/MainFlow.vue
+++ b/frontend/components/MainFlow.vue
@@ -28,7 +28,7 @@
                         :take-events="selectedTakeEvents"
                         :wallet-address="walletAddress"
                         :auction-id="selectedAuctionId"
-                        :are-auctions-fetching="areAuctionsFetching"
+                        :are-auctions-fetching="areAuctionsFetching || isSelectedAuctionFetching"
                         :are-take-events-fetching="areTakeEventsFetching"
                         @restart="$emit('restart', $event)"
                         @connect="$emit('connect')"
@@ -109,6 +109,10 @@ export default Vue.extend({
             default: () => ({}),
         },
         areAuctionsFetching: {
+            type: Boolean,
+            default: false,
+        },
+        isSelectedAuctionFetching: {
             type: Boolean,
             default: false,
         },

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -80,6 +80,7 @@ export default Vue.extend({
                 if (!newAuctionId) {
                     const network = this.$route.query.network;
                     this.$router.push({ query: { network } });
+                    this.update();
                 }
             },
         },
@@ -125,7 +126,7 @@ export default Vue.extend({
             'fetchWalletAuthorizationStatus',
             'fetchCollateralAuthorizationStatus',
         ]),
-        ...mapActions('auctions', ['bidWithCallee', 'bidWithDai', 'restart', 'fetchTakeEventsByAuctionId']),
+        ...mapActions('auctions', ['bidWithCallee', 'bidWithDai', 'restart', 'fetchTakeEventsByAuctionId', 'update']),
         ...mapActions('wallet', ['fetchWalletBalances', 'fetchCollateralVatBalance', 'withdrawAllCollateralFromVat']),
         openSelectWalletModal(): void {
             if (!this.hasAcceptedTerms) {

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -80,7 +80,7 @@ export default Vue.extend({
                 if (!newAuctionId) {
                     const network = this.$route.query.network;
                     this.$router.push({ query: { network } });
-                    this.update();
+                    this.update(true);
                 }
             },
         },

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -6,6 +6,7 @@
             :is-selected-auction-fetching="isSelectedAuctionFetching"
             :are-take-events-fetching="areTakeEventsFetching"
             :auctions-error="auctionsError"
+            :auction-errors="auctionErrors"
             :selected-auction-id.sync="selectedAuctionId"
             :is-explanations-shown.sync="isExplanationsShown"
             :wallet-address="walletAddress"

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -128,7 +128,14 @@ export default Vue.extend({
             'fetchWalletAuthorizationStatus',
             'fetchCollateralAuthorizationStatus',
         ]),
-        ...mapActions('auctions', ['bidWithCallee', 'bidWithDai', 'restart', 'fetchTakeEventsByAuctionId', 'update', 'updateSingleAuction']),
+        ...mapActions('auctions', [
+            'bidWithCallee',
+            'bidWithDai',
+            'restart',
+            'fetchTakeEventsByAuctionId',
+            'update',
+            'updateSingleAuction',
+        ]),
         ...mapActions('wallet', ['fetchWalletBalances', 'fetchCollateralVatBalance', 'withdrawAllCollateralFromVat']),
         openSelectWalletModal(): void {
             if (!this.hasAcceptedTerms) {

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -3,6 +3,7 @@
         <MainFlow
             :auctions="auctions"
             :are-auctions-fetching="areAuctionsFetching"
+            :is-selected-auction-fetching="isSelectedAuctionFetching"
             :are-take-events-fetching="areTakeEventsFetching"
             :auctions-error="auctionsError"
             :selected-auction-id.sync="selectedAuctionId"
@@ -49,6 +50,7 @@ export default Vue.extend({
             auctions: 'listAuctionTransactions',
             takeEvents: 'getTakeEventStorage',
             areAuctionsFetching: 'getAreAuctionsFetching',
+            isSelectedAuctionFetching: 'getIsSelectedAuctionFetching',
             areTakeEventsFetching: 'getAreTakeEventsFetching',
             isAuctionBidding: 'getIsBidding',
             auctionsError: 'getError',
@@ -80,7 +82,7 @@ export default Vue.extend({
                 if (!newAuctionId) {
                     const network = this.$route.query.network;
                     this.$router.push({ query: { network } });
-                    this.update(true);
+                    this.updateSingleAuction(newAuctionId);
                 }
             },
         },
@@ -126,7 +128,7 @@ export default Vue.extend({
             'fetchWalletAuthorizationStatus',
             'fetchCollateralAuthorizationStatus',
         ]),
-        ...mapActions('auctions', ['bidWithCallee', 'bidWithDai', 'restart', 'fetchTakeEventsByAuctionId', 'update']),
+        ...mapActions('auctions', ['bidWithCallee', 'bidWithDai', 'restart', 'fetchTakeEventsByAuctionId', 'update', 'updateSingleAuction']),
         ...mapActions('wallet', ['fetchWalletBalances', 'fetchCollateralVatBalance', 'withdrawAllCollateralFromVat']),
         openSelectWalletModal(): void {
             if (!this.hasAcceptedTerms) {

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -136,7 +136,6 @@ export default Vue.extend({
             'restart',
             'fetchTakeEventsByAuctionId',
             'updateAllAuctions',
-            'updateSingleAuction',
         ]),
         ...mapActions('wallet', ['fetchWalletBalances', 'fetchCollateralVatBalance', 'withdrawAllCollateralFromVat']),
         openSelectWalletModal(): void {

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -84,7 +84,7 @@ export default Vue.extend({
                 if (!newAuctionId) {
                     const network = this.$route.query.network;
                     this.$router.push({ query: { network } });
-                    this.update();
+                    this.updateAllAuctions();
                 }
             },
         },
@@ -135,7 +135,7 @@ export default Vue.extend({
             'bidWithDai',
             'restart',
             'fetchTakeEventsByAuctionId',
-            'update',
+            'updateAllAuctions',
             'updateSingleAuction',
         ]),
         ...mapActions('wallet', ['fetchWalletBalances', 'fetchCollateralVatBalance', 'withdrawAllCollateralFromVat']),

--- a/frontend/containers/AuctionsContainer.vue
+++ b/frontend/containers/AuctionsContainer.vue
@@ -54,6 +54,7 @@ export default Vue.extend({
             areTakeEventsFetching: 'getAreTakeEventsFetching',
             isAuctionBidding: 'getIsBidding',
             auctionsError: 'getError',
+            auctionErrors: 'getAuctionErrors',
             lastUpdated: 'getLastUpdated',
         }),
         ...mapGetters('wallet', {
@@ -82,7 +83,7 @@ export default Vue.extend({
                 if (!newAuctionId) {
                     const network = this.$route.query.network;
                     this.$router.push({ query: { network } });
-                    this.updateSingleAuction(newAuctionId);
+                    this.update();
                 }
             },
         },

--- a/frontend/store/auctions.ts
+++ b/frontend/store/auctions.ts
@@ -155,13 +155,13 @@ export const mutations = {
 };
 
 export const actions = {
-    async update({ rootState, commit, rootGetters }: ActionContext<State, any>) {
+    async update({ rootState, commit, rootGetters }: ActionContext<State, any>, forceUpdateAllAuction?: boolean) {
         const network = rootGetters['network/getMakerNetwork'];
         if (!network) {
             return;
         }
         const selectedAuctionId = rootState.route.query.auction;
-        if (!selectedAuctionId) {
+        if (!selectedAuctionId || forceUpdateAllAuction) {
             commit('setAreAuctionsFetching', true);
             try {
                 const auctions = await fetchAllAuctions(network);

--- a/frontend/store/auctions.ts
+++ b/frontend/store/auctions.ts
@@ -9,13 +9,11 @@ import {
     restartAuction,
     enrichAuctionWithPriceDropAndMarketValue,
     fetchTakeEvents,
-    enrichAuction, fetchSingleAuctionById
-} from "auctions-core/src/auctions";
+    fetchSingleAuctionById,
+} from 'auctions-core/src/auctions';
 import { checkAllCalcParameters } from 'auctions-core/src/params';
 import { checkAllSupportedCollaterals } from 'auctions-core/src/addresses';
 import BigNumber from 'auctions-core/src/bignumber';
-import { fetchAuctionByCollateralTypeAndAuctionIndex } from 'auctions-core/dist/src/fetch';
-import parseAuctionId from 'auctions-core/dist/src/helpers/parseAuctionId';
 import getWallet from '~/lib/wallet';
 import notifier from '~/lib/notifier';
 

--- a/frontend/store/auctions.ts
+++ b/frontend/store/auctions.ts
@@ -159,7 +159,7 @@ export const mutations = {
         state.error = error;
     },
     setErrorByAuctionId(state: State, { auctionId, error }: { auctionId: string; error: string }) {
-        state.auctionErrors[auctionId] = error;
+        Vue.set(state.auctionErrors, auctionId, error);
     },
 };
 

--- a/frontend/store/auctions.ts
+++ b/frontend/store/auctions.ts
@@ -31,7 +31,7 @@ interface State {
     areTakeEventsFetching: boolean;
     isBidding: boolean;
     error: string | null;
-    auctionErrors: Record<string, string>;
+    auctionErrors: Record<string, string | undefined>;
     restartingAuctionsIds: string[];
     lastUpdated: Date | undefined;
 }
@@ -203,7 +203,7 @@ export const actions = {
         try {
             const auction = await fetchSingleAuctionById(network, auctionId);
             commit('setAuction', auction);
-            commit('setErrorByAuctionId', { auctionId, error: null });
+            commit('setErrorByAuctionId', { auctionId, error: undefined });
         } catch (error: any) {
             console.error('fetch auction error', error);
             commit('setErrorByAuctionId', { auctionId, error: error.message });


### PR DESCRIPTION
Closes #223.

I have changed the auction store to act with the following behaviour:
- Collateral Page Loads in, no selected auction -> All Auctions are fetched
  - Auction is selected. While Auction is open, only it will be refetched every 30 seconds
  - On closing of the Auction Panel, the `update` method is called, updating all auctions, to ensure accurate data
- Collateral Page Loads in, auction is selected -> Only the selected Auction loads!
  - On closing of the Auction Panel, the `update` method is called, updating all auctions, to ensure accurate data

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
