### PR TITLE
Added `WSTETH-B` collateral

### DIFF
--- a/core/src/constants/COLLATERALS.ts
+++ b/core/src/constants/COLLATERALS.ts
@@ -261,6 +261,16 @@ const COLLATERALS: Record<string, CollateralConfig> = {
             route: [],
         },
     },
+    'WSTETH-B': {
+        title: 'Lido wstETH',
+        ilk: 'WSTETH-B',
+        symbol: 'WSTETH',
+        decimals: 18,
+        exchange: {
+            callee: 'WstETHCurveUniv3Callee',
+            route: [],
+        },
+    },
     'CRVV1ETHSTETH-A': {
         title: 'Curve stETH',
         ilk: 'CRVV1ETHSTETH-A',


### PR DESCRIPTION
Closes #242 .

Sadly there are no active auctions for this collateral type, so I could not do any testing. Is there a way we can test it before merging @LukSteib?

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
