### PR TITLE
Enabled keeper pre-authorisation for wallet and collaterals

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -31,13 +31,13 @@ $ npm run start
   create new project -> settings -> keys). Note: this project can not be restricted by the origin.
 - `ETHEREUM_NETWORK`: (optional, default `kovan`) – internal network name on which the bot poll for auctions. Available
 - `WHITELISTED_COLLATERALS`: (optional) a comma-separated list of collaterals the bot will fetch. Example: `MATIC-A, UNI-A`
-- `KEEPER_PREAUTHORIZE`: (optional, default false) if set to `true`, all `WHITELISTED_COLLATERALS` will be authorized on startup.
 - `MAX_PRIORITY_FEE_PER_GAS_WEI`: (optional, default can be found in core/src/gas.ts) – [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_priority_fee_per_gas` value
   options can be found in [constants/NETWORKS](../core/src/constants/NETWORKS.ts)
 - `REFETCH_INTERVAL`: (optional, default 60 seconds) – interval between auction fetching requests
 - `KEEPER_*`: (optional) set of env variables to enable keeper bot:
     - `KEEPER_WALLET_PRIVATE_KEY`: (required) The wallet private key (https://metamask.zendesk.com/hc/en-us/articles/360015289632-How-to-Export-an-Account-Private-Key)
     - `KEEPER_MINIMUM_NET_PROFIT_DAI`: (required) The minimum net profit an auction must yield before the keeper automatically bids on it. Can be negative if one is willing to spend ETH on transaction fees to keep DAI stable
+    - `KEEPER_PREAUTHORIZE`: (optional, default false) if set to `true`, all `WHITELISTED_COLLATERALS` will be authorized on startup.
 - `TWITTER_*`: (optional) set of env variables to enable twitter bot. Created via twitter developer account
   with `OAuth 1.0a` `Elevated` access and `Read and Write` permissions:
     - `TWITTER_API_KEY`: (required)

--- a/bot/README.md
+++ b/bot/README.md
@@ -37,7 +37,7 @@ $ npm run start
 - `KEEPER_*`: (optional) set of env variables to enable keeper bot:
     - `KEEPER_WALLET_PRIVATE_KEY`: (required) The wallet private key (https://metamask.zendesk.com/hc/en-us/articles/360015289632-How-to-Export-an-Account-Private-Key)
     - `KEEPER_MINIMUM_NET_PROFIT_DAI`: (required) The minimum net profit an auction must yield before the keeper automatically bids on it. Can be negative if one is willing to spend ETH on transaction fees to keep DAI stable
-    - `KEEPER_PREAUTHORIZE`: (optional, default false) if set to `true`, all `WHITELISTED_COLLATERALS` will be authorized on startup.
+    - `KEEPER_PREAUTHORIZE`: (optional, default `false`) if set to `true`, the wallet will execute all required authorizations (for DAI and collateralals) on start. Default behaviour is to wait until specific auction is profitable and then execute authorizations only required for the particular auction. Note that it's recommended to set this to `true` only in combination with `WHITELISTED_COLLATERALS`
 - `TWITTER_*`: (optional) set of env variables to enable twitter bot. Created via twitter developer account
   with `OAuth 1.0a` `Elevated` access and `Read and Write` permissions:
     - `TWITTER_API_KEY`: (required)

--- a/bot/README.md
+++ b/bot/README.md
@@ -31,6 +31,7 @@ $ npm run start
   create new project -> settings -> keys). Note: this project can not be restricted by the origin.
 - `ETHEREUM_NETWORK`: (optional, default `kovan`) – internal network name on which the bot poll for auctions. Available
 - `WHITELISTED_COLLATERALS`: (optional) a comma-separated list of collaterals the bot will fetch. Example: `MATIC-A, UNI-A`
+- `KEEPER_PREAUTHORIZE`: (optional, default false) if set to `true`, all `WHITELISTED_COLLATERALS` will be authorized on startup.
 - `MAX_PRIORITY_FEE_PER_GAS_WEI`: (optional, default can be found in core/src/gas.ts) – [EIP-1559](https://eips.ethereum.org/EIPS/eip-1559) `max_priority_fee_per_gas` value
   options can be found in [constants/NETWORKS](../core/src/constants/NETWORKS.ts)
 - `REFETCH_INTERVAL`: (optional, default 60 seconds) – interval between auction fetching requests

--- a/bot/src/auctions.ts
+++ b/bot/src/auctions.ts
@@ -25,7 +25,8 @@ export const getNewAuctionsFromActiveAuctions = function (activeActions: Auction
 };
 
 export const getAllAuctions = async function (network: string): Promise<AuctionInitialInfo[]> {
-    const auctions = await fetchAllInitialAuctions(network, getWhitelistedCollaterals());
+    const collaterals = await getWhitelistedCollaterals();
+    const auctions = await fetchAllInitialAuctions(network, collaterals);
 
     const auctionIds = auctions.map(auction => `"${auction.id}"`).join(', ');
     console.info(`auctions: found "${auctions.length}" auctions (${auctionIds}) on "${network}" network`);

--- a/bot/src/authorisation.ts
+++ b/bot/src/authorisation.ts
@@ -8,61 +8,61 @@ import {
 import { ETHEREUM_NETWORK, KEEPER_PREAUTHORIZE } from './variables';
 import { getWhitelistedCollaterals } from './whitelist';
 
-export async function checkAndAuthorizeWallet() {
-    const signer = await getSigner(ETHEREUM_NETWORK);
-    const walletAddress = await signer.getAddress();
+export async function checkAndAuthorizeWallet(walletAddress: string): Promise<boolean> {
     const isWalletAuth = await getWalletAuthorizationStatus(ETHEREUM_NETWORK, walletAddress);
 
-    if (!isWalletAuth) {
-        console.info(`keeper: wallet "${walletAddress}" has not been authorized yet. Attempting authorization now...`);
-        const transactionHash = await authorizeWallet(ETHEREUM_NETWORK, walletAddress, false);
-        console.info(`keeper: wallet "${walletAddress}" successfully authorized via "${transactionHash}" transaction`);
-        return true;
+    if (isWalletAuth) {
+        console.info(`keeper: wallet "${walletAddress}" has already been authorized`);
+        return false;
     }
-    console.info(`keeper: wallet is already authorized`);
-    return false;
+
+    console.info(`keeper: wallet "${walletAddress}" has not been authorized yet. Attempting authorization now...`);
+    const transactionHash = await authorizeWallet(ETHEREUM_NETWORK, walletAddress, false);
+    console.info(`keeper: wallet "${walletAddress}" successfully authorized via "${transactionHash}" transaction`);
+    return true;
 }
 
-export async function checkAndAuthorizeCollateral(walletAddress: string, collateralType: string) {
+export async function checkAndAuthorizeCollateral(walletAddress: string, collateralType: string): Promise<boolean> {
     // get collateral authorization status
     const isCollateralAuth = await getCollateralAuthorizationStatus(ETHEREUM_NETWORK, collateralType, walletAddress);
 
     // try to authorize the collateral then return
-    if (!isCollateralAuth) {
+    if (isCollateralAuth) {
         console.info(
-            `keeper: collateral "${collateralType}" has not been authorized on wallet "${walletAddress}" yet. Attempting authorization now...`
+            `keeper: collateral "${collateralType}" has already been authorized on wallet "${walletAddress}"`
         );
-        const collateralTransactionHash = await authorizeCollateral(
-            ETHEREUM_NETWORK,
-            walletAddress,
-            collateralType,
-            false
-        );
-        console.info(
-            `keeper: collateral "${collateralType}" successfully authorized on wallet "${walletAddress}" via "${collateralTransactionHash}" transaction`
-        );
-        return true;
+        return false;
     }
-    console.info(`keeper: collateral "${collateralType}" has already been authorized on wallet "${walletAddress}".`);
-    return false;
+
+    console.info(
+        `keeper: collateral "${collateralType}" has not been authorized on wallet "${walletAddress}" yet. Attempting authorization now...`
+    );
+    const collateralTransactionHash = await authorizeCollateral(
+        ETHEREUM_NETWORK,
+        walletAddress,
+        collateralType,
+        false
+    );
+    console.info(
+        `keeper: collateral "${collateralType}" successfully authorized on wallet "${walletAddress}" via "${collateralTransactionHash}" transaction`
+    );
+    return true;
 }
 
-export async function setupCollateralAuthorizations() {
-    if (!KEEPER_PREAUTHORIZE) {
+export async function executePreAuthorizationsIfRequested() {
+    if (KEEPER_PREAUTHORIZE !== true) {
         return;
     }
 
-    // check if the wallet is authorized
-    await checkAndAuthorizeWallet();
-
     const collaterals = await getWhitelistedCollaterals();
     console.info(
-        `keeper: "KEEPER_PREAUTHORIZE" is true attempting to authorize collaterals: '${collaterals.toString()}'`
+        `keeper: "KEEPER_PREAUTHORIZE" is true. Attempting to authorize wallet and collaterals: "${collaterals.join(
+            ', '
+        )}"`
     );
-
     const signer = await getSigner(ETHEREUM_NETWORK);
     const walletAddress = await signer.getAddress();
-
+    await checkAndAuthorizeWallet(walletAddress);
     for (const collateral of collaterals) {
         await checkAndAuthorizeCollateral(walletAddress, collateral);
     }

--- a/bot/src/authorisation.ts
+++ b/bot/src/authorisation.ts
@@ -1,0 +1,47 @@
+import getSigner from 'auctions-core/dist/src/signer';
+import {
+    authorizeCollateral,
+    authorizeWallet,
+    getCollateralAuthorizationStatus,
+    getWalletAuthorizationStatus,
+} from 'auctions-core/src/authorizations';
+import { ETHEREUM_NETWORK } from '~/src/variables';
+
+export async function authorizeKeeperWallet(authorizeCallback: () => void) {
+    const signer = await getSigner(ETHEREUM_NETWORK);
+    const walletAddress = await signer.getAddress();
+    const isWalletAuth = await getWalletAuthorizationStatus(ETHEREUM_NETWORK, walletAddress);
+
+    if (!isWalletAuth) {
+        console.info(`keeper: wallet "${walletAddress}" has not been authorized yet. Attempting authorization now...`);
+        const transactionHash = await authorizeWallet(ETHEREUM_NETWORK, walletAddress, false);
+        console.info(`keeper: wallet "${walletAddress}" successfully authorized via "${transactionHash}" transaction`);
+        authorizeCallback();
+    }
+}
+
+export async function checkAndAuthorizeKeeperCollateral(
+    walletAddress: string,
+    collateralType: string,
+    authorizeCallback: () => void
+) {
+    // get collateral authorization status
+    const isCollateralAuth = await getCollateralAuthorizationStatus(ETHEREUM_NETWORK, collateralType, walletAddress);
+
+    // try to authorize the collateral then return
+    if (!isCollateralAuth) {
+        console.info(
+            `keeper: collateral "${collateralType}" has not been authorized on wallet "${walletAddress}" yet. Attempting authorization now...`
+        );
+        const collateralTransactionHash = await authorizeCollateral(
+            ETHEREUM_NETWORK,
+            walletAddress,
+            collateralType,
+            false
+        );
+        console.info(
+            `keeper: collateral "${collateralType}" successfully authorized on wallet "${walletAddress}" via "${collateralTransactionHash}" transaction`
+        );
+        authorizeCallback();
+    }
+}

--- a/bot/src/authorisation.ts
+++ b/bot/src/authorisation.ts
@@ -8,7 +8,7 @@ import {
 import { ETHEREUM_NETWORK, KEEPER_PREAUTHORIZE, WHITELISTED_COLLATERALS } from './variables';
 import { parseCollateralWhitelist } from './whitelist';
 
-export async function authorizeKeeperWallet(authorizeCallback: () => void) {
+export async function authorizeKeeperWallet(authorizeCallback?: () => void) {
     const signer = await getSigner(ETHEREUM_NETWORK);
     const walletAddress = await signer.getAddress();
     const isWalletAuth = await getWalletAuthorizationStatus(ETHEREUM_NETWORK, walletAddress);
@@ -17,7 +17,9 @@ export async function authorizeKeeperWallet(authorizeCallback: () => void) {
         console.info(`keeper: wallet "${walletAddress}" has not been authorized yet. Attempting authorization now...`);
         const transactionHash = await authorizeWallet(ETHEREUM_NETWORK, walletAddress, false);
         console.info(`keeper: wallet "${walletAddress}" successfully authorized via "${transactionHash}" transaction`);
-        authorizeCallback();
+        if (authorizeCallback) {
+            authorizeCallback();
+        }
     }
 }
 
@@ -53,6 +55,10 @@ export async function setupCollateralAuthorizations() {
     if (!KEEPER_PREAUTHORIZE || !WHITELISTED_COLLATERALS) {
         return;
     }
+
+    // check if the wallet is authorized
+    await authorizeKeeperWallet();
+
     const collaterals = parseCollateralWhitelist(WHITELISTED_COLLATERALS);
     console.info(
         `keeper: "KEEPER_PREAUTHORIZE" is true attempting to authorize collaterals: '${collaterals.toString()}'`

--- a/bot/src/authorisation.ts
+++ b/bot/src/authorisation.ts
@@ -5,8 +5,8 @@ import {
     getCollateralAuthorizationStatus,
     getWalletAuthorizationStatus,
 } from 'auctions-core/src/authorizations';
-import { ETHEREUM_NETWORK, KEEPER_PREAUTHORIZE, WHITELISTED_COLLATERALS } from './variables';
-import { parseCollateralWhitelist } from './whitelist';
+import { ETHEREUM_NETWORK, KEEPER_PREAUTHORIZE } from './variables';
+import { getWhitelistedCollaterals } from './whitelist';
 
 export async function checkAndAuthorizeWallet() {
     const signer = await getSigner(ETHEREUM_NETWORK);
@@ -48,14 +48,14 @@ export async function checkAndAuthorizeCollateral(walletAddress: string, collate
 }
 
 export async function setupCollateralAuthorizations() {
-    if (!KEEPER_PREAUTHORIZE || !WHITELISTED_COLLATERALS) {
+    if (!KEEPER_PREAUTHORIZE) {
         return;
     }
 
     // check if the wallet is authorized
     await checkAndAuthorizeWallet();
 
-    const collaterals = parseCollateralWhitelist(WHITELISTED_COLLATERALS);
+    const collaterals = await getWhitelistedCollaterals();
     console.info(
         `keeper: "KEEPER_PREAUTHORIZE" is true attempting to authorize collaterals: '${collaterals.toString()}'`
     );

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -6,7 +6,7 @@ import participate, { setupKeeper } from './keeper';
 import { ETHEREUM_NETWORK } from './variables';
 import { setupTwitter } from './twitter';
 import { setupWhitelist } from './whitelist';
-import { setupCollateralAuthorizations } from './authorisation';
+import { executePreAuthorizationsIfRequested } from './authorisation';
 
 const DEFAULT_REFETCH_INTERVAL = 60 * 1000;
 const SETUP_DELAY = 3 * 1000;
@@ -32,7 +32,7 @@ const start = async function (): Promise<void> {
     setupWhitelist();
     await setupTwitter();
     await setupKeeper();
-    await setupCollateralAuthorizations();
+    await executePreAuthorizationsIfRequested();
     loop();
     setInterval(loop, REFETCH_INTERVAL);
 };

--- a/bot/src/index.ts
+++ b/bot/src/index.ts
@@ -6,6 +6,7 @@ import participate, { setupKeeper } from './keeper';
 import { ETHEREUM_NETWORK } from './variables';
 import { setupTwitter } from './twitter';
 import { setupWhitelist } from './whitelist';
+import { setupCollateralAuthorizations } from './authorisation';
 
 const DEFAULT_REFETCH_INTERVAL = 60 * 1000;
 const SETUP_DELAY = 3 * 1000;
@@ -31,6 +32,7 @@ const start = async function (): Promise<void> {
     setupWhitelist();
     await setupTwitter();
     await setupKeeper();
+    await setupCollateralAuthorizations();
     loop();
     setInterval(loop, REFETCH_INTERVAL);
 };

--- a/bot/src/keeper.ts
+++ b/bot/src/keeper.ts
@@ -82,19 +82,23 @@ const checkAndParticipateIfPossible = async function (auction: AuctionInitialInf
         );
     }
 
-    // get wallet authorization status
     const walletAddress = await signer.getAddress();
 
     // try to authorize the wallet then return
-    const walletNewlyAuthed = await checkAndAuthorizeWallet();
-    if (walletNewlyAuthed) {
+    const wasWalletNewlyAuthorized = await checkAndAuthorizeWallet(walletAddress);
+    if (wasWalletNewlyAuthorized) {
+        // restart auction evaluation in case authorization was executed
         await checkAndParticipateIfPossible(auction);
         return;
     }
 
-    // check the collateral authorization status and authorize it if needed
-    const collateralNewlyAuthed = await checkAndAuthorizeCollateral(walletAddress, auctionTransaction.collateralType);
-    if (collateralNewlyAuthed) {
+    // check the collateral authorization status and authorize if needed
+    const wasCollateralNewlyAuthorized = await checkAndAuthorizeCollateral(
+        walletAddress,
+        auctionTransaction.collateralType
+    );
+    if (wasCollateralNewlyAuthorized) {
+        // restart auction evaluation in case authorization was executed
         await checkAndParticipateIfPossible(auction);
         return;
     }

--- a/bot/src/variables.ts
+++ b/bot/src/variables.ts
@@ -2,3 +2,4 @@ export const ETHEREUM_NETWORK = process.env.ETHEREUM_NETWORK || 'kovan';
 export const KEEPER_MINIMUM_NET_PROFIT_DAI = parseInt(process.env.KEEPER_MINIMUM_NET_PROFIT_DAI || '');
 export const KEEPER_WALLET_PRIVATE_KEY = process.env.KEEPER_WALLET_PRIVATE_KEY;
 export const WHITELISTED_COLLATERALS = process.env.WHITELISTED_COLLATERALS;
+export const KEEPER_PREAUTHORIZE: boolean = process.env.KEEPER_PREAUTHORIZE?.toLowerCase() === 'true' || false;

--- a/bot/src/variables.ts
+++ b/bot/src/variables.ts
@@ -2,4 +2,4 @@ export const ETHEREUM_NETWORK = process.env.ETHEREUM_NETWORK || 'kovan';
 export const KEEPER_MINIMUM_NET_PROFIT_DAI = parseInt(process.env.KEEPER_MINIMUM_NET_PROFIT_DAI || '');
 export const KEEPER_WALLET_PRIVATE_KEY = process.env.KEEPER_WALLET_PRIVATE_KEY;
 export const WHITELISTED_COLLATERALS = process.env.WHITELISTED_COLLATERALS;
-export const KEEPER_PREAUTHORIZE: boolean = process.env.KEEPER_PREAUTHORIZE?.toLowerCase() === 'true' || false;
+export const KEEPER_PREAUTHORIZE: boolean = process.env.KEEPER_PREAUTHORIZE?.toLowerCase().trim() === 'true' || false;

--- a/bot/src/variables.ts
+++ b/bot/src/variables.ts
@@ -2,4 +2,4 @@ export const ETHEREUM_NETWORK = process.env.ETHEREUM_NETWORK || 'kovan';
 export const KEEPER_MINIMUM_NET_PROFIT_DAI = parseInt(process.env.KEEPER_MINIMUM_NET_PROFIT_DAI || '');
 export const KEEPER_WALLET_PRIVATE_KEY = process.env.KEEPER_WALLET_PRIVATE_KEY;
 export const WHITELISTED_COLLATERALS = process.env.WHITELISTED_COLLATERALS;
-export const KEEPER_PREAUTHORIZE: boolean = process.env.KEEPER_PREAUTHORIZE?.toLowerCase().trim() === 'true' || false;
+export const KEEPER_PREAUTHORIZE = process.env.KEEPER_PREAUTHORIZE?.toLowerCase().trim() === 'true' || false;

--- a/bot/src/whitelist.ts
+++ b/bot/src/whitelist.ts
@@ -1,5 +1,6 @@
 import { getCollateralConfigByType } from 'auctions-core/src/constants/COLLATERALS';
-import { WHITELISTED_COLLATERALS } from './variables';
+import { getSupportedCollateralTypes } from 'auctions-core/dist/src/addresses';
+import { ETHEREUM_NETWORK, WHITELISTED_COLLATERALS } from './variables';
 
 const validateWhitelist = function (whitelist: string[]) {
     const unsupportedCollateralTypes: string[] = [];
@@ -17,15 +18,15 @@ const validateWhitelist = function (whitelist: string[]) {
     }
 };
 
-export const parseCollateralWhitelist = function (whitelist: string): string[] {
+const parseCollateralWhitelist = function (whitelist: string): string[] {
     return whitelist.split(',').map(item => item.trim());
 };
 
-export const getWhitelistedCollaterals = function () {
+export const getWhitelistedCollaterals = async function () {
     if (WHITELISTED_COLLATERALS) {
         return parseCollateralWhitelist(WHITELISTED_COLLATERALS);
     }
-    return undefined;
+    return await getSupportedCollateralTypes(ETHEREUM_NETWORK);
 };
 
 export const setupWhitelist = function () {


### PR DESCRIPTION
Closes #264

Tested the new feature on `hardhat` setup. I also verified that the string to boolean parsing is working correctly, ignoring case and spaces.

On first run:
![Screenshot 2022-05-18 at 00 26 21](https://user-images.githubusercontent.com/30908158/168922682-b6c7cc14-cd33-4835-b037-faaf49d7bf28.png)

On second run:
![Screenshot 2022-05-18 at 00 27 23](https://user-images.githubusercontent.com/30908158/168922702-36a9f303-82fa-4c1c-b1b7-6c832af67e9d.png)

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable