### PR TITLE
Fixed HeapIO Integration

### DIFF
--- a/.drone.yml
+++ b/.drone.yml
@@ -24,6 +24,8 @@ data:
           value_from_secret: auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/staging_banner_url
         - key: DEFAULT_ETHEREUM_NETWORK
           value_from_secret: auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/default_etherum_network
+        - key: HEAPIO_ID
+          value_from_secret: auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/heapio_id
       tags_to_cache_from:
         - "main"
       trigger:
@@ -86,6 +88,8 @@ data:
           value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/contact_email
         - key: DEFAULT_ETHEREUM_NETWORK
           value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/default_etherum_network
+        - key: HEAPIO_ID
+          value_from_secret: auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/heapio_id
       tags_to_cache_from:
         - "main"
       trigger:

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -34,7 +34,7 @@ export default {
             { hid: 'description', name: 'description', content: '' },
         ],
         link: [{ rel: 'icon', type: 'image/x-icon', href: '/favicon.ico' }],
-        script: [{ src: 'js/HeapIO.js' }],
+        script: [{ src: '/js/HeapIO.js' }],
     },
 
     // Global CSS: https://go.nuxtjs.dev/config-css
@@ -69,11 +69,6 @@ export default {
     // Plausible.io Settings
     plausible: {
         domain: process.env.PRODUCTION_DOMAIN,
-    },
-
-    // Disable Static Asset Path Prefix: https://nuxtjs.org/docs/directory-structure/static/#static-asset-prefixs
-    static: {
-        prefix: false,
     },
 
     // Build Configuration: https://go.nuxtjs.dev/config-build

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -71,6 +71,7 @@ export default {
         domain: process.env.PRODUCTION_DOMAIN,
     },
 
+    // Disable Static Asset Path Prefix: https://nuxtjs.org/docs/directory-structure/static/#static-asset-prefixs
     static: {
         prefix: false,
     },

--- a/frontend/nuxt.config.js
+++ b/frontend/nuxt.config.js
@@ -71,6 +71,10 @@ export default {
         domain: process.env.PRODUCTION_DOMAIN,
     },
 
+    static: {
+        prefix: false,
+    },
+
     // Build Configuration: https://go.nuxtjs.dev/config-build
     build: {
         // Webpack config


### PR DESCRIPTION
Closes #267 

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable

fixes are:
- Added HeapIO ID to drone file to env variable gets properly set in environments now
- Disabled static prefix for nuxt to page will always look at `~/static` instead of relative to the page.
  - Locally doesn't break anything, checked with T&S file and heapIO. 