### PR TITLE
Rewrote `notification-service` to use RPC URLs

### DIFF
--- a/notification-service/README.md
+++ b/notification-service/README.md
@@ -27,9 +27,8 @@ $ npm run start
 
 Note: env variables are accessible via the `secret` command under `auction-ui/${environment}/notification-service`.
 
-- `INFURA_PROJECT_ID`: (required) [infura](https://infura.io/) project id (can be found in: dashboard -> ethereum ->
+- `WS_URL`: (required) Ethereum Websocket url used for fetching data from the blockchain
 - `ETHERSCAN_API_KEY`: (required) [Etherscan API Key](https://docs.etherscan.io/getting-started/viewing-api-usage-statistics), which is used to automatically download ABIs 
-- `ETHEREUM_NETWORK`: (optional, default `kovan`) – internal network name on which the bot poll for auctions. Available
 - `SMTP_*`: (optional, required for email usage) - SMTP data for the service to send emails
     - `SMTP_HOST`: (required) - SMTP host address
     - `SMTP_PORT`: (optional) - SMTP port. Defaults to `465`

--- a/notification-service/src/constants/NETWORKS.ts
+++ b/notification-service/src/constants/NETWORKS.ts
@@ -1,6 +1,6 @@
 export const NETWORKS: Record<string, { network: string; etherscanURL: string; etherscanAPI: string }> = {
-    mainnet: {
-        network: 'mainnet',
+    homestead: {
+        network: 'homestead',
         etherscanURL: 'https://etherscan.io',
         etherscanAPI: 'https://api.etherscan.io',
     },

--- a/notification-service/src/etherscan.ts
+++ b/notification-service/src/etherscan.ts
@@ -1,4 +1,4 @@
-import { ETHEREUM_NETWORK, ETHERSCAN_API_KEY } from './variables';
+import { ETHERSCAN_API_KEY } from './variables';
 import axios from 'axios';
 import { NETWORKS } from './constants/NETWORKS';
 import { ETHERSCAN_PREFIX } from './constants/PREFIXES';
@@ -17,11 +17,9 @@ export function validateEtherscanAPIKey() {
     }
 }
 
-export async function getAbiFromContractAddress(contract: string) {
+export async function getAbiFromContractAddress(network: string, contract: string) {
     const result = await axios.get(
-        `${getEtherscanAPI(
-            ETHEREUM_NETWORK
-        )}/api?module=contract&action=getabi&address=${contract}&apikey=${ETHERSCAN_API_KEY}`
+        `${getEtherscanAPI(network)}/api?module=contract&action=getabi&address=${contract}&apikey=${ETHERSCAN_API_KEY}`
     );
 
     if (result.data.message !== 'OK') {

--- a/notification-service/src/index.ts
+++ b/notification-service/src/index.ts
@@ -1,5 +1,4 @@
 import 'dotenv/config';
-import { ETHEREUM_NETWORK } from './variables';
 import { listenForEvents, setupWebSocket } from './websocket';
 import { isNetworkSupported } from './constants/NETWORKS';
 import { validateReceiverList } from './recievers';
@@ -7,14 +6,13 @@ import { validateEtherscanAPIKey } from './etherscan';
 import { notify, setupNotifiers } from './notifiers';
 
 const start = async function () {
-    isNetworkSupported(ETHEREUM_NETWORK);
     validateEtherscanAPIKey();
     validateReceiverList();
 
     const notifiers = await setupNotifiers();
-    const wsProvider = await setupWebSocket();
-
-    listenForEvents(wsProvider, eventData => notify(notifiers, eventData));
+    const { wsProvider, networkTitle } = await setupWebSocket();
+    isNetworkSupported(networkTitle);
+    listenForEvents(wsProvider, networkTitle, eventData => notify(notifiers, eventData));
 };
 
 start().catch(error => {

--- a/notification-service/src/index.ts
+++ b/notification-service/src/index.ts
@@ -12,7 +12,7 @@ const start = async function () {
     const notifiers = await setupNotifiers();
     const { wsProvider, networkTitle } = await setupWebSocket();
     isNetworkSupported(networkTitle);
-    listenForEvents(wsProvider, networkTitle, eventData => notify(notifiers, eventData));
+    listenForEvents(wsProvider, networkTitle, eventData => notify(networkTitle, notifiers, eventData));
 };
 
 start().catch(error => {

--- a/notification-service/src/notifiers.ts
+++ b/notification-service/src/notifiers.ts
@@ -13,7 +13,7 @@ export async function setupNotifiers(): Promise<Notifiers> {
     };
 }
 
-export function notify(notifiers: Notifiers, eventData: EventData) {
+export function notify(network: string, notifiers: Notifiers, eventData: EventData) {
     console.info(
         `${EVENT_PREFIX} "${eventData.eventSubscription.id}" triggered in block "${eventData.event.blockNumber}"`
     );
@@ -21,11 +21,11 @@ export function notify(notifiers: Notifiers, eventData: EventData) {
     const receivers = getReceiversForSubscriptionId(eventData.eventSubscription.id);
 
     // Notify per mail
-    notifyPerMail(notifiers.mailer, eventData, getReceiversByType(receivers, 'email')).catch(error =>
+    notifyPerMail(network, notifiers.mailer, eventData, getReceiversByType(receivers, 'email')).catch(error =>
         console.error(error)
     );
     // Notify per discord
-    notifyPerDiscord(eventData, getReceiversByType(receivers, 'discord')).catch(error => {
+    notifyPerDiscord(network, eventData, getReceiversByType(receivers, 'discord')).catch(error => {
         console.error(error);
     });
 }

--- a/notification-service/src/notifiers/discord.ts
+++ b/notification-service/src/notifiers/discord.ts
@@ -1,22 +1,21 @@
 import { EventData } from '../types';
 import axios from 'axios';
 import { generateDiscordMessage } from '../generators/generateDiscordMessage';
-import { ETHEREUM_NETWORK } from '../variables';
 import { formatEtherscanLink } from '../etherscan';
 
 const DISCORD_PREFIX = '💬 [discord]:';
 
-export async function notifyPerDiscord(eventData: EventData, receivers: string[]) {
+export async function notifyPerDiscord(network: string, eventData: EventData, receivers: string[]) {
     if (receivers.length <= 0) {
         return;
     }
 
     const formattedData = eventData.eventSubscription
-        .formatData(eventData.event, (type, content) => formatEtherscanLink(ETHEREUM_NETWORK, type, content))
+        .formatData(eventData.event, (type, content) => formatEtherscanLink(network, type, content))
         .replace('<br />', '');
 
     const discordMessage = generateDiscordMessage(
-        ETHEREUM_NETWORK,
+        network,
         eventData.eventSubscription,
         eventData.event,
         formattedData

--- a/notification-service/src/notifiers/mailer.ts
+++ b/notification-service/src/notifiers/mailer.ts
@@ -2,7 +2,7 @@ import nodemailer from 'nodemailer';
 import SMTPTransport from 'nodemailer/lib/smtp-transport';
 import validator from 'validator';
 import * as showdown from 'showdown';
-import { ETHEREUM_NETWORK, SMTP_EMAIL, SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USERNAME } from '../variables';
+import { SMTP_EMAIL, SMTP_HOST, SMTP_PASSWORD, SMTP_PORT, SMTP_USERNAME } from '../variables';
 import { EventData, MailData } from '../types';
 import { formatEtherscanLink } from '../etherscan';
 import generateEmailHTMLBody, { generateEmailSubject, generateEmailTextBody } from '../generators/generateEmail';
@@ -71,6 +71,7 @@ export function validateEmailReceivers(receivers: string[]) {
 }
 
 export async function notifyPerMail(
+    network: string,
     transporter: nodemailer.Transporter<SMTPTransport.SentMessageInfo> | undefined,
     eventData: EventData,
     receivers: string[]
@@ -85,18 +86,13 @@ export async function notifyPerMail(
 
     const formattedData = converter.makeHtml(
         eventData.eventSubscription.formatData(eventData.event, (type, content) =>
-            formatEtherscanLink(ETHEREUM_NETWORK, type, content)
+            formatEtherscanLink(network, type, content)
         )
     );
 
-    const emailSubject = generateEmailSubject(ETHEREUM_NETWORK, eventData.eventSubscription.id);
-    const emailTextBody = generateEmailTextBody(ETHEREUM_NETWORK, eventData.eventSubscription);
-    const emailHTMLBody = generateEmailHTMLBody(
-        ETHEREUM_NETWORK,
-        eventData.eventSubscription,
-        eventData.event,
-        formattedData
-    );
+    const emailSubject = generateEmailSubject(network, eventData.eventSubscription.id);
+    const emailTextBody = generateEmailTextBody(network, eventData.eventSubscription);
+    const emailHTMLBody = generateEmailHTMLBody(network, eventData.eventSubscription, eventData.event, formattedData);
 
     const mailData: MailData = {
         receivers: receivers.toString(),

--- a/notification-service/src/variables.ts
+++ b/notification-service/src/variables.ts
@@ -1,6 +1,5 @@
-export const INFURA_PROJECT_ID = process.env.INFURA_PROJECT_ID;
+export const WS_URL = process.env.WS_URL;
 export const ETHERSCAN_API_KEY = process.env.ETHERSCAN_API_KEY;
-export const ETHEREUM_NETWORK = process.env.ETHEREUM_NETWORK || 'kovan';
 
 export const SMTP_HOST = process.env.SMTP_HOST;
 export const SMTP_PORT = parseInt(process.env.SMTP_PORT || '465');

--- a/notification-service/src/websocket.ts
+++ b/notification-service/src/websocket.ts
@@ -1,28 +1,29 @@
 import { ethers } from 'ethers';
-import { INFURA_PROJECT_ID, ETHEREUM_NETWORK } from './variables';
+import { WS_URL } from './variables';
 import { SUBSCRIPTIONS } from './constants/SUBSCRIPTIONS';
 import { WEBSOCKET_PREFIX } from './constants/PREFIXES';
 import { EventData, EventSubscription } from './types';
 import { getAbiFromContractAddress } from './etherscan';
 
-export async function setupWebSocket(): Promise<ethers.providers.WebSocketProvider> {
-    if (!INFURA_PROJECT_ID) {
-        throw new Error(`${WEBSOCKET_PREFIX} please set a valid INFURA_PROJECT_ID, in the environment files`);
+export async function setupWebSocket(): Promise<{
+    wsProvider: ethers.providers.WebSocketProvider;
+    networkTitle: string;
+}> {
+    if (!WS_URL) {
+        throw new Error(`${WEBSOCKET_PREFIX} please set a valid WS_URL, in the environment files`);
     }
 
-    const wsProvider = new ethers.providers.WebSocketProvider(
-        `wss://${ETHEREUM_NETWORK}.infura.io/ws/v3/${INFURA_PROJECT_ID}`,
-        ETHEREUM_NETWORK
-    );
+    const wsProvider = new ethers.providers.WebSocketProvider(WS_URL);
 
-    await wsProvider.getNetwork();
+    const networkInfo = await wsProvider.getNetwork();
 
-    console.info(`${WEBSOCKET_PREFIX} websocket connection opened to "${ETHEREUM_NETWORK}" network`);
-    return wsProvider;
+    console.info(`${WEBSOCKET_PREFIX} websocket connection opened to "${networkInfo.name}" network`);
+    return { wsProvider, networkTitle: networkInfo.name };
 }
 
 export function listenForEvents(
     wsProvider: ethers.providers.WebSocketProvider,
+    network: string,
     triggerEvent: (eventData: EventData) => void
 ) {
     const contracts: Record<string, EventSubscription[]> = {};
@@ -37,7 +38,7 @@ export function listenForEvents(
 
     Object.keys(contracts).forEach(async contractAddress => {
         try {
-            const contractAbi = await getAbiFromContractAddress(contractAddress);
+            const contractAbi = await getAbiFromContractAddress(network, contractAddress);
             const contract = new ethers.Contract(contractAddress, contractAbi, wsProvider);
             const eventNames = contracts[contractAddress].map(eventSubscription => {
                 return eventSubscription.eventName;


### PR DESCRIPTION
Contributes to #330

I saw that in #330 we did not rewrite the `notification-service` to use RPC URLs, so I opened this PR to fix this!

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable