### PR TITLE
Fixed a storybook warning about identical stories

### DIFF
--- a/frontend/components/utils/FormatCurrency.stories.js
+++ b/frontend/components/utils/FormatCurrency.stories.js
@@ -59,20 +59,20 @@ storiesOf('Utils/FormatCurrency', module)
         data: () => ({ amount: new BigNumber(0.0000000000001) }),
         template: '<FormatCurrency :value="amount" currency="dai" />',
     }))
-    .add('Number -0.0000000000001', () => ({
+    .add('Number negative 0.0000000000001', () => ({
         ...common,
         template: '<FormatCurrency :value="-0.0000000000001" currency="dai" />',
     }))
-    .add('BigNumber -0.0000000000001', () => ({
+    .add('BigNumber negative 0.0000000000001', () => ({
         ...common,
         data: () => ({ amount: new BigNumber(-0.0000000000001) }),
         template: '<FormatCurrency :value="amount" currency="dai" />',
     }))
-    .add('Number -10', () => ({
+    .add('Number negative 10', () => ({
         ...common,
         template: '<FormatCurrency :value="-10" currency="dai" />',
     }))
-    .add('BigNumber -10', () => ({
+    .add('BigNumber negative 10', () => ({
         ...common,
         data: () => ({ amount: new BigNumber(-10) }),
         template: '<FormatCurrency :value="amount" currency="dai" />',


### PR DESCRIPTION
Whenever we ran storybook or our tests we got the following warnings:

``` js
console.warn
    Story with id utils-formatcurrency--number-0-0000000000001 already exists in the store!
    
    Perhaps you added the same story twice, or you have a name collision?
    Story ids need to be unique -- ensure you aren't using the same names modulo url-sanitization.

      60 |         template: '<FormatCurrency :value="amount" currency="dai" />',
      61 |     }))
    > 62 |     .add('Number -0.0000000000001', () => ({
         |      ^
      63 |         ...common,
      64 |         template: '<FormatCurrency :value="-0.0000000000001" currency="dai" />',
      65 |     }))

      at Object.warn (node_modules/@storybook/client-logger/dist/cjs/index.js:67:65)
      at StoryStore.addStory (node_modules/@storybook/client-api/dist/cjs/story_store.js:636:30)
      at Object.add (node_modules/@storybook/client-api/dist/cjs/client_api.js:273:27)
      at Object.<anonymous> (components/utils/FormatCurrency.stories.js:62:6)
``` 

This annoyed me so I looked into it. It turns out that you cannot only use a `-` to differentiate two stories. Meaning:

`story 1` and `story -1` are seen as the same story, hence the warning. 

Therefore I renamed some stories that used this naming scheme and changed any referenced negative number from:
`story -1`  to `story negative 1` to avoid confusion for users and the system. This also clears up our console when running jest tests, making debugging easier. 