### PR TITLE
add workflow to auto-add issues to public board

### DIFF
--- a/.github/workflows/auto-add-issues-to-project-public.yaml
+++ b/.github/workflows/auto-add-issues-to-project-public.yaml
@@ -1,0 +1,51 @@
+# This workflow adds a newly created issue to the public management board
+#
+# The project can be found here: https://github.com/orgs/sidestream-tech/projects?type=beta
+# To get the `PROJECT_ID` of project with `url_number=PROJECT_NUMBER_FROM_GITHUB_PROJECTS_URL` used in belows action, execute the following commands using the github `gh` cli:
+#
+# ```sh
+# > gh auth login
+# > gh api graphql -f query='
+#     query($org: String!, $number: Int!) {
+#       organization(login: $org){
+#         projectNext(number: $number) {
+#           id
+#           fields(first:20) {
+#             nodes {
+#               id
+#               name
+#               settings
+#             }
+#           }
+#         }
+#       }
+#     }' -f org=sidestream-tech -F number=PROJECT_NUMBER_FROM_GITHUB_PROJECTS_URL --jq '.data.organization.projectNext.id'
+# ```
+#
+# The `GH_WORKFLOW_TOKEN` of this flow needs the following permissions:
+# - admin:org - as project boards are organization wide
+# - repo - this full level is sadly required in order to manage repository issues
+
+name: Add issue to the public management board
+on:
+  issues:
+    types:
+      - opened
+jobs:
+  add_issue_to_project:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Add issue to project
+        env:
+          GITHUB_TOKEN: ${{ secrets.GH_WORKFLOW_TOKEN }}
+          ISSUE_ID: ${{ github.event.issue.node_id }}
+          PROJECT_ID: ${{ secrets.GH_PROJECT_ID_AUCTIONS_UI }}
+        run: |
+          gh api graphql -f query='
+            mutation($project:ID!, $issue:ID!) {
+              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
+                projectNextItem {
+                  id
+                }
+              }
+            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID


### PR DESCRIPTION
Closes https://github.com/sidestream-tech/auction-ui/issues/427.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable
