### PR TITLE
Hotfix: Updated `ChangeWalletNetworkModal` to use new network logic

### DIFF
--- a/frontend/components/modals/ChangeWalletNetworkModal.vue
+++ b/frontend/components/modals/ChangeWalletNetworkModal.vue
@@ -33,7 +33,6 @@
 <script lang="ts">
 import { Modal, Alert } from 'ant-design-vue';
 import Vue, { PropType } from 'vue';
-import { getNetworks } from 'auctions-core/src/network';
 import BaseButton from '~/components/common/inputs/BaseButton';
 
 export default Vue.extend({
@@ -55,7 +54,7 @@ export default Vue.extend({
     },
     computed: {
         isWalletNetworkSupportedByTheWebsite(): boolean {
-            return !!getNetworks(this.isDev)[this.invalidNetwork];
+            return !!this.networks.find(n => n.type === this.invalidNetwork);
         },
         options() {
             return [...this.networks.map(eachNetwork => ({ label: eachNetwork.title, value: eachNetwork.type }))];


### PR DESCRIPTION
Closes #370 

![Screenshot 2022-07-21 at 16 28 42](https://user-images.githubusercontent.com/30908158/180239415-1be39b4e-3df5-46f4-b0aa-917c400c45d1.png)

Context:
The force network switch modal was still attempting to import an outdated function from the core folder to determine if the network exists. This made it appear as if even the mainnet was not supported by the UI. How did our tests not find this mistake @valiafetisov?

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
