### PR TITLE
Added Unified `CollectAuctionPanel` for multiple Auction Types

### DIFF
--- a/frontend/components/auction/surplus/SurplusAuctionTransactionFlow.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionTransactionFlow.vue
@@ -60,7 +60,7 @@
                 :is-correct.sync="isHighestBidder"
                 @bid="$emit('bid', $event)"
             />
-            <CollectSurplusAuctionPanel
+            <CollectAuctionPanel
                 :auction="auction"
                 :wallet-address="walletAddress"
                 :is-collecting="auctionActionState === 'collecting'"
@@ -93,14 +93,14 @@ import WalletConnectionCheckPanel from '~/components/panels/WalletConnectionChec
 import WalletMKRBalanceCheckPanel from '~/components/panels/WalletMKRBalanceCheckPanel.vue';
 import AllowanceAmountCheckPanel from '~/components/panels/AllowanceAmountCheckPanel.vue';
 import HighestBidCheckPanel from '~/components/panels/HighestBidCheckPanel.vue';
-import CollectSurplusAuctionPanel from '~/components/panels/CollectSurplusAuctionPanel.vue';
+import CollectAuctionPanel from '~/components/panels/CollectAuctionPanel.vue';
 import WithdrawDAIPanel from '~/components/panels/WithdrawDAIPanel.vue';
 import SurplusAuctionBidTransactionTable from '~/components/auction/surplus/SurplusAuctionBidTransactionTable.vue';
 import TextBlock from '~/components/common/other/TextBlock.vue';
 
 export default Vue.extend({
     components: {
-        CollectSurplusAuctionPanel,
+        CollectAuctionPanel,
         AllowanceAmountCheckPanel,
         WalletMKRBalanceCheckPanel,
         HighestBidCheckPanel,

--- a/frontend/components/panels/CollectAuctionPanel.stories.js
+++ b/frontend/components/panels/CollectAuctionPanel.stories.js
@@ -1,21 +1,23 @@
 import { storiesOf } from '@storybook/vue';
-import CollectSurplusAuctionPanel from './CollectSurplusAuctionPanel';
+import CollectAuctionPanel from './CollectAuctionPanel';
 import { generateFakeSurplusAuction } from '~/helpers/generateFakeSurplusAuction';
+import { generateFakeDebtAuction } from '~/helpers/generateFakeDebtAuction';
 
 const fakeSurplusAuction = generateFakeSurplusAuction('have-bids');
+const fakeDebtAuction = generateFakeDebtAuction('have-bids');
 const fakeFinishedSurplusAuction = generateFakeSurplusAuction('ready-for-collection');
 const fakeCollectedSurplusAuction = generateFakeSurplusAuction('collected');
 
 const common = {
-    components: { CollectSurplusAuctionPanel },
+    components: { CollectAuctionPanel },
     template: `
-    <CollectSurplusAuctionPanel 
+    <CollectAuctionPanel 
         v-bind="$data"
     />
     `,
 };
 
-storiesOf('Panels/CollectSurplusAuctionPanel', module)
+storiesOf('Panels/CollectAuctionPanel', module)
     .add('No bids yet', () => ({
         ...common,
         data: () => ({
@@ -67,5 +69,12 @@ storiesOf('Panels/CollectSurplusAuctionPanel', module)
             auction: fakeFinishedSurplusAuction,
             walletAddress: fakeFinishedSurplusAuction.receiverAddress,
             isCollecting: true,
+        }),
+    }))
+    .add('Debt Auction', () => ({
+        ...common,
+        data: () => ({
+            auction: fakeDebtAuction,
+            currency: 'MKR',
         }),
     }));

--- a/frontend/components/panels/CollectAuctionPanel.vue
+++ b/frontend/components/panels/CollectAuctionPanel.vue
@@ -35,7 +35,13 @@
                 @click="$emit('collect')"
             >
                 <span v-if="isCollecting">Collecting...</span>
-                <span v-else>Collect <format-currency :value="auction.receiveAmountDAI" :currency="currency" /> </span>
+                <span v-else
+                    >Collect
+                    <format-currency
+                        :value="auction.receiveAmountDAI || auction.receiveAmountMKR"
+                        :currency="currency"
+                    />
+                </span>
             </BaseButton>
         </div>
     </BasePanel>

--- a/frontend/components/panels/CollectAuctionPanel.vue
+++ b/frontend/components/panels/CollectAuctionPanel.vue
@@ -35,7 +35,7 @@
                 @click="$emit('collect')"
             >
                 <span v-if="isCollecting">Collecting...</span>
-                <span v-else>Collect <format-currency :value="auction.receiveAmountDAI" currency="DAI" /> </span>
+                <span v-else>Collect <format-currency :value="auction.receiveAmountDAI" :currency="currency" /> </span>
             </BaseButton>
         </div>
     </BasePanel>
@@ -43,7 +43,7 @@
 
 <script lang="ts">
 import Vue from 'vue';
-import { SurplusAuction } from 'auctions-core/src/types';
+import { DebtAuction, SurplusAuction } from 'auctions-core/src/types';
 import TextBlock from '~/components/common/other/TextBlock.vue';
 import FormatCurrency from '~/components/common/formatters/FormatCurrency.vue';
 import BaseButton from '~/components/common/inputs/BaseButton.vue';
@@ -51,11 +51,11 @@ import TimeTill from '~/components/common/formatters/TimeTill.vue';
 import BasePanel from '~/components/common/other/BasePanel.vue';
 
 export default Vue.extend({
-    name: 'CollectSurplusAuctionPanel',
+    name: 'CollectAuctionPanel',
     components: { TimeTill, FormatCurrency, TextBlock, BasePanel, BaseButton },
     props: {
         auction: {
-            type: Object as Vue.PropType<SurplusAuction>,
+            type: Object as Vue.PropType<SurplusAuction | DebtAuction>,
             default: undefined,
         },
         walletAddress: {
@@ -65,6 +65,10 @@ export default Vue.extend({
         isCollecting: {
             type: Boolean,
             default: false,
+        },
+        currency: {
+            type: String,
+            default: 'DAI',
         },
     },
     computed: {
@@ -79,36 +83,36 @@ export default Vue.extend({
             if (this.auction.state === 'just-started') {
                 return {
                     name: 'inactive',
-                    title: `Collecting DAI will not be possible until at least one bid`,
+                    title: `Collecting ${this.currency} will not be possible until at least one bid`,
                 };
             }
             if (this.auction.state === 'ready-for-collection') {
                 if (this.isCurrentWalletHighestBidder) {
                     return {
                         name: 'notice',
-                        title: `Auctioned DAI is ready to be collected`,
+                        title: `Auctioned ${this.currency} is ready to be collected`,
                     };
                 }
                 return {
                     name: 'inactive',
-                    title: `Auctioned DAI is ready to be collected, but you're not the winner`,
+                    title: `Auctioned ${this.currency} is ready to be collected, but you're not the winner`,
                 };
             }
             if (this.auction.state === 'collected') {
                 return {
                     name: this.isCurrentWalletHighestBidder ? 'correct' : 'inactive',
-                    title: `Auctioned DAI has been collected`,
+                    title: `Auctioned ${this.currency} has been collected`,
                 };
             }
             if (this.isCurrentWalletHighestBidder) {
                 return {
                     name: 'notice',
-                    title: `Collecting DAI will be possible in `,
+                    title: `Collecting ${this.currency} will be possible in `,
                 };
             }
             return {
                 name: 'inactive',
-                title: `Collecting DAI will be possible in `,
+                title: `Collecting ${this.currency} will be possible in `,
             };
         },
     },


### PR DESCRIPTION
Closes #399

I made one single `CollectAuctionPanel` that takes Debt and Surplus Auctions. You can also customize the currency symbol displayed. Check the unified stories of the Panel for a preview of what it looks like with MKR. 

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
