### PR TITLE
Added Debt Auctions Service to Unified Page

### DIFF
--- a/frontend/components/unified/UnifiedAuctionsView.vue
+++ b/frontend/components/unified/UnifiedAuctionsView.vue
@@ -94,6 +94,16 @@ export default Vue.extend({
                     filters: ['surplus'],
                 },
                 {
+                    title: 'Debt auctions portal',
+                    description:
+                        'Web tool that supports participation in debt auctions by bidding on MKR with own Dai',
+                    links: {
+                        source: 'https://github.com/sidestream-tech/unified-auctions-ui',
+                        participate: '/debt',
+                    },
+                    filters: ['debt'],
+                },
+                {
                     title: 'Liquidations platform',
                     description: 'Web tool that support participation in collateral auctions by bidding with own Dai',
                     links: {


### PR DESCRIPTION
Quick PR that adds the new `/debt` page to the Unified Auctions view.

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
