### PR TITLE
Updated Bot ReadMe to reflect correct config

### DIFF
--- a/bot/README.md
+++ b/bot/README.md
@@ -34,8 +34,8 @@ $ npm run start
 -   `REFETCH_INTERVAL`: (optional, default 60 seconds) – interval between auction fetching requests
 -   `KEEPER_*`: (optional) set of env variables to enable keeper bot:
     -   `KEEPER_WALLET_PRIVATE_KEY`: (required) The wallet private key (https://metamask.zendesk.com/hc/en-us/articles/360015289632-How-to-Export-an-Account-Private-Key)
-    -   `KEEPER_COLLATERAL_MINIMUM_NET_PROFIT_DAI`: (required if `KEEPER_COLLATERAL` is set to `true`) The minimum net profit a collateral auction must yield before the keeper automatically bids on it. Can be negative if one is willing to spend ETH on transaction fees to keep DAI stable
-    -   `KEEPER_SURPLUS_MINIMUM_NET_PROFIT_DAI`: (required if `KEEPER_SURPLUS` is set to `true`) The minimum net profit a surplus auction must yield before the keeper automatically bids on it. Can be negative if one is willing to spend ETH on transaction fees to keep DAI stable
+    -   `KEEPER_COLLATERAL_MINIMUM_NET_PROFIT_DAI`: (required to run keeper on collateral auctions) The minimum net profit a collateral auction must yield before the keeper automatically bids on it. Can be negative if one is willing to spend ETH on transaction fees to keep DAI stable
+    -   `KEEPER_SURPLUS_MINIMUM_NET_PROFIT_DAI`: (required to run keeper on surplus auctions) The minimum net profit a surplus auction must yield before the keeper automatically bids on it. Can be negative if one is willing to spend ETH on transaction fees to keep DAI stable
     -   `KEEPER_PREAUTHORIZE`: (optional, default `false`) if set to `true`, the wallet will execute all required authorizations (for DAI and collateralals) on start. Default behaviour is to wait until specific auction is profitable and then execute authorizations only required for the particular auction. Note that it's recommended to set this to `true` only in combination with `WHITELISTED_COLLATERALS`
 -   `TWITTER_*`: (optional) set of env variables to enable twitter bot. Created via twitter developer account
     with `OAuth 1.0a` `Elevated` access and `Read and Write` permissions:


### PR DESCRIPTION
While checking the merge of #417 I noticed that the ReadMe was slightly outdated and referred to deprecated environment variables. This small PR updates the ReadMe to reflect how the keeper currently works.

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
