### PR TITLE
Minor surplus fixes

### DIFF
--- a/core/package.json
+++ b/core/package.json
@@ -9,7 +9,7 @@
     "start": "node .",
     "test": "npx hardhat test --network testnetwork --config local.hardhat.config.ts",
     "lint": "eslint --ext \".js,.ts\" --ignore-path .gitignore . --max-warnings=0",
-    "hardhat:silent": "npx hardhat node 1>&/dev/null",
+    "hardhat:silent": "npx hardhat node &> /dev/null",
     "hardhat": "npx hardhat node",
     "hardhat:simulations": "npx hardhat --network testnetwork --config local.hardhat.config.ts run ./simulations/index.ts",
     "simulate": "npm-run-all --parallel hardhat:silent hardhat:simulations"

--- a/core/src/surplus.ts
+++ b/core/src/surplus.ts
@@ -205,11 +205,14 @@ export const enrichSurplusAuction = async (
     network: string,
     auction: SurplusAuctionActive
 ): Promise<SurplusAuctionTransaction> => {
-    const nextMinimumBid = await getNextMinimumBid(network, auction);
+    let nextMinimumBid = await getNextMinimumBid(network, auction);
     const unitPrice = auction.bidAmountMKR.div(auction.receiveAmountDAI);
     const marketUnitPrice = await getMarketPriceMkr(network, auction.bidAmountMKR);
     const marketUnitPriceToUnitPriceRatio = unitPrice.minus(marketUnitPrice).dividedBy(marketUnitPrice);
     const fees = await getSurplusTransactionFees(network);
+    if (nextMinimumBid.isZero()) {
+        nextMinimumBid = new BigNumber(1000).plus(fees.combinedBidFeesDai).div(marketUnitPrice);
+    }
     return {
         ...auction,
         ...fees,

--- a/core/src/surplus.ts
+++ b/core/src/surplus.ts
@@ -207,11 +207,14 @@ export const enrichSurplusAuction = async (
 ): Promise<SurplusAuctionTransaction> => {
     let nextMinimumBid = await getNextMinimumBid(network, auction);
     const unitPrice = auction.bidAmountMKR.div(auction.receiveAmountDAI);
-    const marketUnitPrice = await getMarketPriceMkr(network, auction.bidAmountMKR);
+    let marketUnitPrice = await getMarketPriceMkr(network, auction.bidAmountMKR);
     const marketUnitPriceToUnitPriceRatio = unitPrice.minus(marketUnitPrice).dividedBy(marketUnitPrice);
     const fees = await getSurplusTransactionFees(network);
     if (nextMinimumBid.isZero()) {
         nextMinimumBid = new BigNumber(1000).plus(fees.combinedBidFeesDai).div(marketUnitPrice);
+    }
+    if (marketUnitPrice.isNaN()) {
+        marketUnitPrice = await convertMkrToDai(network, new BigNumber(1));
     }
     return {
         ...auction,

--- a/frontend/components/auction/surplus/SurplusAuction.vue
+++ b/frontend/components/auction/surplus/SurplusAuction.vue
@@ -27,14 +27,7 @@
                         <tr>
                             <td>Auction State</td>
                             <td>
-                                <span v-if="isActive">Ends in </span>
-                                <span v-else-if="requiresRestart">Requires restart</span>
-                                <span v-else-if="auction.state === 'ready-for-collection'">Ended </span>
-                                <span v-else>Collected </span>
-                                <time-till
-                                    v-if="auction.earliestEndDate && !requiresRestart"
-                                    :date="auction.earliestEndDate"
-                                />
+                                <SurplusAuctionState :state="auction.state" :end-date="auction.earliestEndDate" />
                             </td>
                         </tr>
                         <tr>
@@ -148,6 +141,7 @@
 import Vue from 'vue';
 import type { CompensationAuctionActionStates, SurplusAuctionTransaction } from 'auctions-core/src/types';
 import { Alert, Tooltip } from 'ant-design-vue';
+import SurplusAuctionState from '~/components/auction/surplus/SurplusAuctionState.vue';
 import TextBlock from '~/components/common/other/TextBlock.vue';
 import TimeTill from '~/components/common/formatters/TimeTill.vue';
 import Button from '~/components/common/inputs/BaseButton.vue';
@@ -161,6 +155,7 @@ export default Vue.extend({
     name: 'SurplusAuction',
     components: {
         AuctionRestartPanel,
+        SurplusAuctionState,
         FormatCurrency,
         TextBlock,
         TimeTill,

--- a/frontend/components/auction/surplus/SurplusAuctionBidTransactionTable.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionBidTransactionTable.vue
@@ -3,7 +3,7 @@
         <div class="flex justify-between">
             <div>Auction State</div>
             <div>
-                <SurplusAuctionState :state="auction.state" :end-date="auction.auctionEndDate" />
+                <SurplusAuctionState :state="auction.state" :end-date="auction.earliestEndDate" />
             </div>
         </div>
         <div class="flex justify-between">

--- a/frontend/components/auction/surplus/SurplusAuctionBidTransactionTable.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionBidTransactionTable.vue
@@ -57,7 +57,7 @@
         <div class="flex justify-between">
             <div>Price on Uniswap</div>
             <div>
-                <format-currency
+                <FormatCurrency
                     v-if="auction.marketUnitPrice && isActive"
                     :value="auction.marketUnitPrice"
                     :decimal-places="6"
@@ -69,7 +69,7 @@
         <div class="flex justify-between font-bold">
             <div>Price after the bid</div>
             <div>
-                <format-currency
+                <FormatCurrency
                     v-if="unitPriceAfterBid && isActive && !isBidAmountNaN"
                     :value="unitPriceAfterBid"
                     :decimal-places="6"

--- a/frontend/components/auction/surplus/SurplusAuctionBidTransactionTable.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionBidTransactionTable.vue
@@ -3,7 +3,7 @@
         <div class="flex justify-between">
             <div>Auction State</div>
             <div>
-                <time-till :date="auction.auctionEndDate" />
+                <SurplusAuctionState :state="auction.state" :end-date="auction.auctionEndDate" />
             </div>
         </div>
         <div class="flex justify-between">
@@ -82,16 +82,16 @@
 </template>
 
 <script lang="ts">
-import type { SurplusAuction } from 'auctions-core/src/types';
 import Vue from 'vue';
 import BigNumber from 'bignumber.js';
-import BidInput from '../../common/inputs/BidInput.vue';
-import TimeTill from '~/components/common/formatters/TimeTill.vue';
+import type { SurplusAuction } from 'auctions-core/src/types';
+import SurplusAuctionState from '~/components/auction/surplus/SurplusAuctionState.vue';
+import BidInput from '~/components/common/inputs/BidInput.vue';
 import FormatCurrency from '~/components/common/formatters/FormatCurrency.vue';
 
 export default Vue.extend({
     components: {
-        TimeTill,
+        SurplusAuctionState,
         FormatCurrency,
         BidInput,
     },

--- a/frontend/components/auction/surplus/SurplusAuctionBidTransactionTable.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionBidTransactionTable.vue
@@ -84,7 +84,7 @@
 <script lang="ts">
 import Vue from 'vue';
 import BigNumber from 'bignumber.js';
-import type { SurplusAuction } from 'auctions-core/src/types';
+import type { SurplusAuctionTransaction } from 'auctions-core/src/types';
 import SurplusAuctionState from '~/components/auction/surplus/SurplusAuctionState.vue';
 import BidInput from '~/components/common/inputs/BidInput.vue';
 import FormatCurrency from '~/components/common/formatters/FormatCurrency.vue';
@@ -97,7 +97,7 @@ export default Vue.extend({
     },
     props: {
         auction: {
-            type: Object as Vue.PropType<SurplusAuction>,
+            type: Object as Vue.PropType<SurplusAuctionTransaction>,
             required: true,
         },
     },

--- a/frontend/components/auction/surplus/SurplusAuctionState.stories.js
+++ b/frontend/components/auction/surplus/SurplusAuctionState.stories.js
@@ -1,0 +1,22 @@
+import { storiesOf } from '@storybook/vue';
+import faker from 'faker';
+import SurplusAuctionState from './SurplusAuctionState';
+
+const common = {
+    components: { SurplusAuctionState },
+    data: () => ({
+        state: faker.helpers.randomize([
+            'just-started',
+            'have-bids',
+            'ready-for-collection',
+            'requires-restart',
+            'collected',
+        ]),
+        endDate: new Date(faker.date.recent()),
+    }),
+};
+
+storiesOf('Auction/Surplus/SurplusAuctionState', module).add('Default', () => ({
+    ...common,
+    template: '<SurplusAuctionState :state="state" :end-date="endDate" />',
+}));

--- a/frontend/components/auction/surplus/SurplusAuctionState.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionState.vue
@@ -1,0 +1,32 @@
+<template>
+    <div>
+        <span v-if="state === 'collected'"> Collected </span>
+        <span v-else-if="state === 'requires-restart'"> Requires Restart </span>
+        <span v-else-if="state === 'ready-for-collection'"> Collectable since </span>
+        <span v-else> Expires in </span>
+        <TimeTill v-if="state !== 'requires-restart'" :date="endDate" />
+    </div>
+</template>
+
+<script lang="ts">
+import Vue from 'vue';
+import { SurplusAuctionStates } from 'auctions-core/src/types';
+import TimeTill from '~/components/common/formatters/TimeTill.vue';
+
+export default Vue.extend({
+    name: 'SurplusAuctionState',
+    components: {
+        TimeTill,
+    },
+    props: {
+        state: {
+            type: String as Vue.PropType<SurplusAuctionStates>,
+            required: true,
+        },
+        endDate: {
+            type: Date,
+            required: true,
+        },
+    },
+});
+</script>

--- a/frontend/components/auction/surplus/SurplusAuctionState.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionState.vue
@@ -24,8 +24,8 @@ export default Vue.extend({
             required: true,
         },
         endDate: {
-            type: Date,
-            required: true,
+            type: [String, Number, Date],
+            default: '',
         },
     },
 });

--- a/frontend/components/auction/surplus/SurplusAuctionState.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionState.vue
@@ -3,7 +3,7 @@
         <span v-if="state === 'collected'"> Collected </span>
         <span v-else-if="state === 'requires-restart'"> Requires Restart </span>
         <span v-else-if="state === 'ready-for-collection'"> Collectable since </span>
-        <span v-else> Expires in </span>
+        <span v-else> Ends in </span>
         <TimeTill v-if="state !== 'requires-restart'" :date="endDate" />
     </div>
 </template>

--- a/frontend/components/auction/surplus/SurplusAuctionTransactionFlow.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionTransactionFlow.vue
@@ -84,7 +84,7 @@
 </template>
 
 <script lang="ts">
-import type { SurplusAuction } from 'auctions-core/src/types';
+import type { SurplusAuctionTransaction } from 'auctions-core/src/types';
 import Vue from 'vue';
 import { Alert } from 'ant-design-vue';
 import BigNumber from 'bignumber.js';
@@ -112,7 +112,7 @@ export default Vue.extend({
     },
     props: {
         auction: {
-            type: Object as Vue.PropType<SurplusAuction>,
+            type: Object as Vue.PropType<SurplusAuctionTransaction>,
             required: true,
         },
         auctionActionState: {

--- a/frontend/components/auction/surplus/SurplusAuctionsTable.vue
+++ b/frontend/components/auction/surplus/SurplusAuctionsTable.vue
@@ -41,11 +41,7 @@
                 <span v-else class="opacity-50">Unknown</span>
             </div>
             <div slot="state" slot-scope="state, record">
-                <span v-if="state === 'collected'"> Collected </span>
-                <span v-else-if="state === 'requires-restart'"> Requires Restart </span>
-                <span v-else-if="state === 'ready-for-collection'"> Collectable since </span>
-                <span v-else> Expires in </span>
-                <time-till v-if="state !== 'requires-restart'" :date="record.earliestEndDate" />
+                <SurplusAuctionState :state="state" :end-date="record.earliestEndDate" />
             </div>
             <div slot="updatingStatus" class="opacity-50 font-normal">
                 <div v-if="isLoading" class="flex items-center space-x-2">
@@ -76,13 +72,14 @@
 <script lang="ts">
 import Vue, { PropType } from 'vue';
 import { Table } from 'ant-design-vue';
-import { SurplusAuctionTransaction } from 'auctions-core/src/types';
 import { compareAsc } from 'date-fns';
+import { SurplusAuctionTransaction } from 'auctions-core/src/types';
+import LoadingIcon from '~/assets/icons/loading.svg';
+import SurplusAuctionState from '~/components/auction/surplus/SurplusAuctionState.vue';
 import Loading from '~/components/common/other/Loading.vue';
 import TimeTill from '~/components/common/formatters/TimeTill.vue';
 import FormatMarketValue from '~/components/common/formatters/FormatMarketValue.vue';
 import FormatCurrency from '~/components/common/formatters/FormatCurrency.vue';
-import LoadingIcon from '~/assets/icons/loading.svg';
 
 const compareBy = function (field: string, cmp: Function = (a: number, b: number): number => a - b): Function {
     return (aAuction: any, bAuction: any, sortOrder: string) => {
@@ -145,6 +142,7 @@ const STATES_FILTERS: { text: string; value: string }[] = [
 export default Vue.extend({
     name: 'SurplusAuctionsTable',
     components: {
+        SurplusAuctionState,
         Loading,
         Table,
         TimeTill,


### PR DESCRIPTION
Closes #450.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable

Issues to be fixed:
- [x] Fix uniswap price fetching when there is no bids
- [x] Set `nextMinimumBid` to make sense (eg a uniswap price * gap to reach 1k net profit)
- [x] `SurplusAuctionBidTransactionTable` "state" should display state, not just date
- [x] `SurplusAuctionBidTransactionTable` end state should count down, but count up (ie Ended 2s ago, 3s ago, etc. First guess: can be caused by invalid determination of the `earliestEndDate`)