### PR TITLE
Improve format date component

### DIFF
--- a/frontend/components/common/formatters/TimeTill.stories.js
+++ b/frontend/components/common/formatters/TimeTill.stories.js
@@ -23,4 +23,8 @@ storiesOf('Common/Formatters/TimeTill', module)
             date: new Date(Date.now() + 5000).toUTCString(),
         }),
         template: `<TimeTill :date="date" />`,
+    }))
+    .add('Invalid date', () => ({
+        components: { TimeTill },
+        template: `<TimeTill date="Invalid Date" />`,
     }));

--- a/frontend/components/vault/Vault.stories.js
+++ b/frontend/components/vault/Vault.stories.js
@@ -46,4 +46,17 @@ storiesOf('Vault/Vault', module)
     .add('Not found', () => ({
         ...common,
         template: `<Vault :vaultId='vaultId' />`,
+    }))
+    .add('Invalid Date', () => ({
+        ...common,
+        data() {
+            return {
+                vault: {
+                    ...fakeVaultNotLiquidatedTransaction,
+                    nextPriceChange: 'Invalid Date',
+                },
+                vaultId: fakeVaultLiquidatedTransaction.id.toString(),
+            };
+        },
+        template: `<Vault :vaultTransaction="vault" :vaultId='vaultId' @liquidate="liquidate" />`,
     }));

--- a/frontend/components/vault/Vault.vue
+++ b/frontend/components/vault/Vault.vue
@@ -30,14 +30,20 @@
                         <tr>
                             <td>Next price update</td>
                             <td>
-                                <div v-if="vaultTransaction.nextPriceChange" class="flex items-center space-x-1">
+                                <div class="flex items-center space-x-1">
                                     <AnimatedArrow
                                         :direction="getIsPriceGoingUpOrDown(vaultTransaction)"
                                         class="h-4 opacity-50"
                                     />
-                                    <span>in <TimeTill :date="vaultTransaction.nextPriceChange" /></span>
+                                    <span
+                                        v-if="
+                                            vaultTransaction.nextPriceChange &&
+                                            vaultTransaction.nextPriceChange instanceof Date
+                                        "
+                                        >in <TimeTill :date="vaultTransaction.nextPriceChange"
+                                    /></span>
+                                    <span v-else class="opacity-50">Unknown</span>
                                 </div>
-                                <span v-else class="opacity-50">Unknown</span>
                             </td>
                         </tr>
                         <tr>


### PR DESCRIPTION
Closes #523 

If the date is not a javascript date object the following is displayed:

![Screenshot 2022-11-14 at 17 31 10](https://user-images.githubusercontent.com/30908158/201713987-12a1fab0-a357-4f74-a4ca-768f6bb13e5e.png)

I added a new story to check this behavior -> `Vault/Vault/Invalid Date` 

Checklist:
- [X] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [X] issue checkboxes are all addressed
- [X] manually checked my feature / not applicable
- [X] wrote tests / not applicable
- [X] attached screenshots / not applicable
