### PR TITLE
Remove hardcoded gas price

### DIFF
--- a/core/src/network.ts
+++ b/core/src/network.ts
@@ -15,7 +15,6 @@ const SUPPORTED_NETWORKS: NetworkConfig[] = [
         chainId: '0x5',
         type: 'goerli',
         title: 'Goerli',
-        gasPrice: 2000000000,
         url: '',
         etherscanUrl: 'https://goerli.etherscan.io',
         isFork: false,


### PR DESCRIPTION
Closes #526.

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable

---

### Solution description

- We were hardcoding the gas price for `goerli` [here](https://github.com/sidestream-tech/unified-auctions-ui/blob/cbf572753d9dde45d03ff63be8a62cbe03f70548/core/src/network.ts#L18).
- When we call [`getGasParametersForTransaction()`](https://github.com/sidestream-tech/unified-auctions-ui/blob/cbf572753d9dde45d03ff63be8a62cbe03f70548/core/src/gas.ts#L45), we use the hardcoded gas price if it's available.
- Removing the hardcoded gas price forces the function to properly get the gas price