### PR TITLE
Disable number formatting after decimal point

### DIFF
--- a/core/src/helpers/formatToAutomaticDecimalPoints.ts
+++ b/core/src/helpers/formatToAutomaticDecimalPoints.ts
@@ -60,7 +60,9 @@ function limitedValue(value: number | BigNumber): number | BigNumber {
 
 export function formatWithThousandSeparators(value: string): string {
     // We choose regex over native JS solutions, as using native solutions only support numbers
-    return value.replace(/(\d)(?=(\d\d\d)+(?!\d))/g, '$1,');
+    const parts = value.toString().split('.');
+    parts[0] = parts[0].replace(/\B(?=(\d{3})+(?!\d))/g, ',');
+    return parts.join('.');
 }
 
 interface formatToAutomaticDecimalPointsOptions {


### PR DESCRIPTION
Doesn't close anything, but fixes formatting of the numbers

Previously:
<img width="113" alt="Screenshot 2022-12-06 at 18 04 36" src="https://user-images.githubusercontent.com/3393626/205976093-49996cce-f647-4943-ab68-b3362f487a6a.png">

Now:
<img width="106" alt="Screenshot 2022-12-06 at 18 05 13" src="https://user-images.githubusercontent.com/3393626/205976235-7ceac964-1c1c-458e-a11b-f532fa46c21c.png">
