### PR TITLE
update add-to-project workflow

### DIFF
--- a/.github/workflows/auto-add-issues-to-project-public.yaml
+++ b/.github/workflows/auto-add-issues-to-project-public.yaml
@@ -1,51 +1,22 @@
-# This workflow adds a newly created issue to the public management board
-#
-# The project can be found here: https://github.com/orgs/sidestream-tech/projects?type=beta
-# To get the `PROJECT_ID` of project with `url_number=PROJECT_NUMBER_FROM_GITHUB_PROJECTS_URL` used in belows action, execute the following commands using the github `gh` cli:
-#
-# ```sh
-# > gh auth login
-# > gh api graphql -f query='
-#     query($org: String!, $number: Int!) {
-#       organization(login: $org){
-#         projectNext(number: $number) {
-#           id
-#           fields(first:20) {
-#             nodes {
-#               id
-#               name
-#               settings
-#             }
-#           }
-#         }
-#       }
-#     }' -f org=sidestream-tech -F number=PROJECT_NUMBER_FROM_GITHUB_PROJECTS_URL --jq '.data.organization.projectNext.id'
-# ```
-#
 # The `GH_WORKFLOW_TOKEN` of this flow needs the following permissions:
 # - admin:org - as project boards are organization wide
-# - repo - this full level is sadly required in order to manage repository issues
+# - repo:status, deployment, public_repo
+# - project:read 
+# `GH_PROJECT_URL` is the URL of the Projectboard being used in the format:
+# - https://github.com/orgs/<orgName>/projects/<projectNumber>
+name: Add issue to project "SIDESTREAM"
 
-name: Add issue to the public management board
 on:
   issues:
     types:
       - opened
+
 jobs:
-  add_issue_to_project:
+  add-to-project:
+    name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - name: Add issue to project
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_WORKFLOW_TOKEN }}
-          ISSUE_ID: ${{ github.event.issue.node_id }}
-          PROJECT_ID: ${{ secrets.GH_PROJECT_ID_AUCTIONS_UI }}
-        run: |
-          gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
-                  id
-                }
-              }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: https://github.com/orgs/sidestream-tech/projects/11
+          github-token: ${{ secrets.GH_WORKFLOW_TOKEN }}

--- a/.github/workflows/auto-add-issues-to-project.yaml
+++ b/.github/workflows/auto-add-issues-to-project.yaml
@@ -1,51 +1,22 @@
-# This workflow adds a newly created issue to the main organization-project
-#
-# The project can be found here: https://github.com/orgs/sidestream-tech/projects?type=beta
-# To get the `PROJECT_ID` of project with `url_number=PROJECT_NUMBER_FROM_GITHUB_PROJECTS_URL` used in belows action, execute the following commands using the github `gh` cli:
-#
-# ```sh
-# > gh auth login
-# > gh api graphql -f query='
-#     query($org: String!, $number: Int!) {
-#       organization(login: $org){
-#         projectNext(number: $number) {
-#           id
-#           fields(first:20) {
-#             nodes {
-#               id
-#               name
-#               settings
-#             }
-#           }
-#         }
-#       }
-#     }' -f org=sidestream-tech -F number=PROJECT_NUMBER_FROM_GITHUB_PROJECTS_URL --jq '.data.organization.projectNext.id'
-# ```
-#
 # The `GH_WORKFLOW_TOKEN` of this flow needs the following permissions:
 # - admin:org - as project boards are organization wide
-# - repo - this full level is sadly required in order to manage repository issues
+# - repo:status, deployment, public_repo
+# - project:read 
+# `GH_PROJECT_URL` is the URL of the Projectboard being used in the format:
+# - https://github.com/orgs/<orgName>/projects/<projectNumber>
+name: Add issue to project "SIDESTREAM"
 
-name: Add issue to the main organization-project
 on:
   issues:
     types:
       - opened
+
 jobs:
-  add_issue_to_project:
+  add-to-project:
+    name: Add issue to project
     runs-on: ubuntu-latest
     steps:
-      - name: Add issue to project
-        env:
-          GITHUB_TOKEN: ${{ secrets.GH_WORKFLOW_TOKEN }}
-          ISSUE_ID: ${{ github.event.issue.node_id }}
-          PROJECT_ID: ${{ secrets.GH_PROJECT_ID }}
-        run: |
-          gh api graphql -f query='
-            mutation($project:ID!, $issue:ID!) {
-              addProjectNextItem(input: {projectId: $project, contentId: $issue}) {
-                projectNextItem {
-                  id
-                }
-              }
-            }' -f project=$PROJECT_ID -f issue=$ISSUE_ID
+      - uses: actions/add-to-project@v0.4.0
+        with:
+          project-url: ${{ secrets.GH_PROJECT_URL }}
+          github-token: ${{ secrets.GH_WORKFLOW_TOKEN }}


### PR DESCRIPTION
Contributes to  https://github.com/sidestream-tech/devops/issues/161

Updates the `add-issue-to-project` workflow to use the newest GitHub GraphQL API with the help of an [action](https://github.com/actions/add-to-project)

Feature got successfully tested beforehand in the `devops` repo! 

Checklist:
- [x] issue number linked above after pound (`#`)
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- [x] issue checkboxes are all addressed
- [x] manually checked my feature / not applicable
- [x] wrote tests / not applicable
- [x] attached screenshots / not applicable
