### PR TITLE
Ensure reth participation

### DIFF
--- a/core/src/calleeFunctions/rETHCurveUniv3Callee.ts
+++ b/core/src/calleeFunctions/rETHCurveUniv3Callee.ts
@@ -24,7 +24,7 @@ const getCalleeData = async function (
     if (!preloadedPools) {
         throw new Error(`Can not encode route for the "${collateral.ilk}" without preloaded pools`);
     }
-    const route = await encodePools(network, preloadedPools);
+    const route = await encodePools(network, preloadedPools.slice(1));
     const joinAdapterAddress = await getContractAddressByName(network, getJoinNameByCollateralType(collateral.ilk));
     const minProfit = 1;
     const typesArray = ['address', 'address', 'uint256', 'bytes', 'address'];


### PR DESCRIPTION
This PR ensures participation in rETH auctions via the callee. Tested via the keeper bot and rETH simulation inside hardhat:

```
ℹ wallet: setup complete, using wallet "0xdD2FD4581271e230360230F9337D5c0430Bf44C0"                                                                                                               10:46:46
ℹ collateral keeper: setup complete, looking for minimum net profit of "-1000000" DAI                                                                                                             10:46:46
ℹ debt keeper: setup complete, looking for minimum net profit of "10" DAI                                                                                                                         10:46:46
ℹ debt auctions: found "0" auctions "" on "custom" network                                                                                                                                        10:47:05
ℹ collateral auctions: found "1" auctions "RETH-A:2" on "custom" network                                                                                                                          10:47:05
ℹ collateral auctions: "1" of "1" auctions are new                                                                                                                                                10:47:05
ℹ Collateral auction notification: "Collateral auction with 7.26 RETH just started. Follow the link to participate: https://localhost:3000/collateral/?network=custom&auction=RETH-A:2"           10:47:05

 WARN  twitter: tweet is skipped due to the dev mode: "Collateral auction with 7.26 RETH just started. Follow the link to participate: https://localhost:3000/collateral/?network=custom&auction=RETH-A:2"

ℹ collateral keeper: auction "RETH-A:2" net profit is 4157 DAI after transaction fees, moving on to the execution                                                                                 10:47:14
ℹ keeper: wallet "0xdD2FD4581271e230360230F9337D5c0430Bf44C0" has not been authorized yet. Attempting authorization now...                                                                        10:47:14
ℹ Transaction is preparing to be mined...                                                                                                                                                         10:47:14
ℹ Transaction is pending to be mined...                                                                                                                                                           10:47:14
ℹ Transaction was mined into block "19266387"                                                                                                                                                     10:47:14
ℹ keeper: wallet "0xdD2FD4581271e230360230F9337D5c0430Bf44C0" successfully authorized via "0x6fdc59650605fd121f03b14843bb1fa24d8b346fed197f369d175d0d6b4d9042" transaction                        10:47:14
ℹ collateral keeper: auction "RETH-A:2" net profit is 4157 DAI after transaction fees, moving on to the execution                                                                                 10:47:14
ℹ keeper: wallet "0xdD2FD4581271e230360230F9337D5c0430Bf44C0" has already been authorized                                                                                                         10:47:14
ℹ keeper: collateral "RETH-A" has not been authorized on wallet "0xdD2FD4581271e230360230F9337D5c0430Bf44C0" yet. Attempting authorization now...                                                 10:47:14
ℹ Transaction is preparing to be mined...                                                                                                                                                         10:47:14
ℹ Transaction is pending to be mined...                                                                                                                                                           10:47:14
ℹ Transaction was mined into block "19266388"                                                                                                                                                     10:47:14
ℹ keeper: collateral "RETH-A" successfully authorized on wallet "0xdD2FD4581271e230360230F9337D5c0430Bf44C0" via "0xaefe9c0d1db55298b0397b3354f49f4c58a37ecdebbe830a7348a340abcb0a9f" transaction 10:47:14
ℹ collateral keeper: auction "RETH-A:2" net profit is 4157 DAI after transaction fees, moving on to the execution                                                                                 10:47:14
ℹ keeper: wallet "0xdD2FD4581271e230360230F9337D5c0430Bf44C0" has already been authorized                                                                                                         10:47:14
ℹ keeper: collateral "RETH-A" has already been authorized on wallet "0xdD2FD4581271e230360230F9337D5c0430Bf44C0"                                                                                  10:47:14
ℹ collateral keeper: auction "RETH-A:2": attempting swap execution                                                                                                                                10:47:14
ℹ Transaction is preparing to be mined...                                                                                                                                                         10:47:14
ℹ Transaction is pending to be mined...                                                                                                                                                           10:47:21
ℹ Transaction was mined into block "19266389"                                                                                                                                                     10:47:21
ℹ collateral keeper: auction "RETH-A:2" was succesfully executed via "0xe1901ca3272125b29b1511e41fee030d420cbbc77aa9acdb584655f9b2e053ce" transaction                                             10:47:21
```

