### PR TITLE
Vault liquidation by address

### DIFF
--- a/core/src/constants/COLLATERALS.ts
+++ b/core/src/constants/COLLATERALS.ts
@@ -22,6 +22,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'AAVE',
         tokenName: 'AAVE',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'AAVE',
             pip: 'PIP_AAVE',
@@ -51,6 +52,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'BAL',
         tokenName: 'BAL',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'BAL',
             pip: 'PIP_BAL',
@@ -80,6 +82,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'BAT',
         tokenName: 'BAT',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'BAT',
             pip: 'PIP_BAT',
@@ -109,6 +112,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'COMP',
         tokenName: 'COMP',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'COMP',
             pip: 'PIP_COMP',
@@ -138,6 +142,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'GNO',
         tokenName: 'GNO',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'GNO',
             pip: 'PIP_GNO',
@@ -163,6 +168,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'ETH',
         tokenName: 'ETH',
         decimals: 18,
+        isActive: true,
         contracts: {
             token: 'ETH',
             pip: 'PIP_ETH',
@@ -192,6 +198,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'ETH',
         tokenName: 'ETH',
         decimals: 18,
+        isActive: true,
         contracts: {
             token: 'ETH',
             pip: 'PIP_ETH',
@@ -221,6 +228,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'ETH',
         tokenName: 'ETH',
         decimals: 18,
+        isActive: true,
         contracts: {
             token: 'ETH',
             pip: 'PIP_ETH',
@@ -250,6 +258,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'GUSD',
         tokenName: 'GUSD',
         decimals: 2,
+        isActive: false,
         contracts: {
             token: 'GUSD',
             pip: 'PIP_GUSD',
@@ -279,6 +288,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'KNC',
         tokenName: 'KNC',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'KNC',
             pip: 'PIP_KNC',
@@ -308,6 +318,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'LINK',
         tokenName: 'LINK',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'LINK',
             pip: 'PIP_LINK',
@@ -337,6 +348,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'LRC',
         tokenName: 'LRC',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'LRC',
             pip: 'PIP_LRC',
@@ -366,6 +378,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'MANA',
         tokenName: 'MANA',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'MANA',
             pip: 'PIP_MANA',
@@ -395,6 +408,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'PAXUSD',
         tokenName: 'PAXUSD',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'PAXUSD',
             pip: 'PIP_PAXUSD',
@@ -425,6 +439,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'RENBTC',
         tokenName: 'RENBTC',
         decimals: 8,
+        isActive: false,
         contracts: {
             token: 'RENBTC',
             pip: 'PIP_RENBTC',
@@ -454,6 +469,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'TUSD',
         tokenName: 'TUSD',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'TUSD',
             pip: 'PIP_TUSD',
@@ -483,6 +499,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNI',
         tokenName: 'UNI',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNI',
             pip: 'PIP_UNI',
@@ -512,6 +529,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'USDC',
         tokenName: 'USDC',
         decimals: 6,
+        isActive: false,
         contracts: {
             token: 'USDC',
             pip: 'PIP_USDC',
@@ -541,6 +559,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'USDC',
         tokenName: 'USDC',
         decimals: 6,
+        isActive: false,
         contracts: {
             token: 'USDC',
             pip: 'PIP_USDC',
@@ -570,6 +589,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'USDT',
         tokenName: 'USDT',
         decimals: 6,
+        isActive: false,
         contracts: {
             token: 'USDT',
             pip: 'PIP_USDT',
@@ -599,6 +619,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'WBTC',
         tokenName: 'WBTC',
         decimals: 8,
+        isActive: true,
         contracts: {
             token: 'WBTC',
             pip: 'PIP_WBTC',
@@ -628,6 +649,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'WBTC',
         tokenName: 'WBTC',
         decimals: 8,
+        isActive: true,
         contracts: {
             token: 'WBTC',
             pip: 'PIP_WBTC',
@@ -657,6 +679,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'WBTC',
         tokenName: 'WBTC',
         decimals: 8,
+        isActive: true,
         contracts: {
             token: 'WBTC',
             pip: 'PIP_WBTC',
@@ -686,6 +709,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'YFI',
         tokenName: 'YFI',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'YFI',
             pip: 'PIP_YFI',
@@ -715,6 +739,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'ZRX',
         tokenName: 'ZRX',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'ZRX',
             pip: 'PIP_ZRX',
@@ -744,6 +769,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'MATIC',
         tokenName: 'MATIC',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'MATIC',
             pip: 'PIP_MATIC',
@@ -773,6 +799,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'WSTETH',
         tokenName: 'WSTETH',
         decimals: 18,
+        isActive: true,
         contracts: {
             token: 'WSTETH',
             pip: 'PIP_WSTETH',
@@ -794,6 +821,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'WSTETH',
         tokenName: 'WSTETH',
         decimals: 18,
+        isActive: true,
         contracts: {
             token: 'WSTETH',
             pip: 'PIP_WSTETH',
@@ -815,6 +843,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'CRVV1ETHSTETH',
         tokenName: 'CRVV1ETHSTETH',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'CRVV1ETHSTETH',
             pip: 'PIP_CRVV1ETHSTETH',
@@ -836,6 +865,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2DAIETH',
         tokenName: 'UNIV2DAIETH',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2DAIETH',
             pip: 'PIP_UNIV2DAIETH',
@@ -858,6 +888,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2USDCETH',
         tokenName: 'UNIV2USDCETH',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2USDCETH',
             pip: 'PIP_UNIV2USDCETH',
@@ -880,6 +911,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2ETHUSDT',
         tokenName: 'UNIV2ETHUSDT',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2ETHUSDT',
             pip: 'PIP_UNIV2ETHUSDT',
@@ -902,6 +934,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2WBTCDAI',
         tokenName: 'UNIV2WBTCDAI',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2WBTCDAI',
             pip: 'PIP_UNIV2WBTCDAI',
@@ -924,6 +957,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2WBTCETH',
         tokenName: 'UNIV2WBTCETH',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2WBTCETH',
             pip: 'PIP_UNIV2WBTCETH',
@@ -946,6 +980,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2LINKETH',
         tokenName: 'UNIV2LINKETH',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2LINKETH',
             pip: 'PIP_UNIV2LINKETH',
@@ -968,6 +1003,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2UNIETH',
         tokenName: 'UNIV2UNIETH',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2UNIETH',
             pip: 'PIP_UNIV2UNIETH',
@@ -990,6 +1026,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2AAVEETH',
         tokenName: 'UNIV2AAVEETH',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2AAVEETH',
             pip: 'PIP_UNIV2AAVEETH',
@@ -1012,6 +1049,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2DAIUSDT',
         tokenName: 'UNIV2DAIUSDT',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2DAIUSDT',
             pip: 'PIP_UNIV2DAIUSDT',
@@ -1034,6 +1072,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'UNIV2DAIUSDC',
         tokenName: 'UNIV2DAIUSDC',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'UNIV2DAIUSDC',
             pip: 'PIP_UNIV2DAIUSDC',
@@ -1056,6 +1095,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'RETH',
         tokenName: 'RETH',
         decimals: 18,
+        isActive: false,
         contracts: {
             token: 'RETH',
             pip: 'PIP_RETH',
@@ -1077,6 +1117,7 @@ const COLLATERALS: Record<string, CollateralConfig> = {
         symbol: 'MCD_GOV',
         tokenName: 'MKR',
         decimals: 18,
+        isActive: true,
         contracts: {
             token: 'MCD_GOV',
             pip: 'PIP_MKR',
@@ -1116,6 +1157,12 @@ export const getAllCollateralSymbols = function (): string[] {
 
 export const getAllCollateralTypes = function (): string[] {
     return Object.keys(COLLATERALS).sort();
+};
+
+export const getActiveCollateralTypes = function (): string[] {
+    return Object.values(COLLATERALS)
+        .filter(config => config.isActive)
+        .map(config => config.ilk);
 };
 
 export default COLLATERALS;

--- a/core/src/types.ts
+++ b/core/src/types.ts
@@ -169,6 +169,7 @@ export declare interface CollateralConfig {
     symbol: string;
     tokenName: string;
     decimals: number;
+    isActive: boolean;
     exchanges: Record<string, CalleeConfig>;
     oracle: CollateralPriceSourceConfig;
     contracts: CollateralAddresses;
@@ -405,7 +406,6 @@ export declare interface VaultCollateralParameters {
 }
 
 export declare interface VaultBase {
-    id: number;
     address: string;
     collateralType: CollateralType;
     network: string;

--- a/core/test/vault-test.ts
+++ b/core/test/vault-test.ts
@@ -39,7 +39,6 @@ const compareVaultTransactionsNotLiquidated = (
     expect(expected.liquidationRatio.toFixed()).to.eq(actual.liquidationRatio.toFixed());
     expect(expected.collateralizationRatio.toFixed()).to.eq(actual.collateralizationRatio.toFixed());
     expect(expected.proximityToLiquidation.toFixed()).to.eq(actual.proximityToLiquidation.toFixed());
-    expect(expected.id).to.eq(actual.id);
     expect(expected.incentiveCombinedDai.toFixed()).to.eq(actual.incentiveCombinedDai.toFixed());
     expect(expected.incentiveRelativeDai.toFixed()).to.eq(actual.incentiveRelativeDai.toFixed());
     expect(expected.incentiveConstantDai.toFixed()).to.eq(actual.incentiveConstantDai.toFixed());
@@ -87,7 +86,6 @@ describe('Vaults', () => {
             proximityToLiquidation: new BigNumber('0.547552318511616565008415094516004867207418444'),
             liquidationPenaltyRatio: new BigNumber('1.13'),
             minimalAuctionedDai: new BigNumber('15000'),
-            id: 22025,
 
             incentiveCombinedDai: new BigNumber('34051.78882788199615657274955'),
             incentiveRelativeDai: new BigNumber('33751.78882788199615657274955'),
@@ -146,7 +144,6 @@ describe('Vaults', () => {
             proximityToLiquidation: new BigNumber('-0.000993196126304112564617120755317536277614422'),
             liquidationPenaltyRatio: new BigNumber('1.13'),
             minimalAuctionedDai: new BigNumber('5000'),
-            id: 27435,
 
             incentiveCombinedDai: new BigNumber('310.00197961786050681518163'),
             incentiveRelativeDai: new BigNumber('10.00197961786050681518163'),

--- a/frontend/components/panels/VaultLiquidationPanel.stories.js
+++ b/frontend/components/panels/VaultLiquidationPanel.stories.js
@@ -10,7 +10,7 @@ const common = {
     components: { VaultLiquidationPanel },
     data() {
         return {
-            vaultId: vaultTransaction.id,
+            vaultAddress: vaultTransaction.address,
             vaultState: vaultTransaction.state,
             network: vaultTransaction.network,
             walletAddress: faker.finance.ethereumAddress(),

--- a/frontend/components/panels/VaultLiquidationPanel.vue
+++ b/frontend/components/panels/VaultLiquidationPanel.vue
@@ -27,7 +27,7 @@
                 :is-loading="isLiquidating"
                 @click="$emit('liquidate', walletAddress)"
             >
-                Liquidate vault #{{ vaultId }}
+                <span>Liquidate vault&nbsp;<FormatAddress shorten :value="vaultAddress" /></span>
             </BaseButton>
         </div>
     </BasePanel>
@@ -40,6 +40,7 @@ import ExecuteWithOtherWalletModal from '../modals/ExecuteWithOtherWalletModal.v
 import BaseButton from '~/components/common/inputs/BaseButton.vue';
 import TextBlock from '~/components/common/other/TextBlock.vue';
 import BasePanel from '~/components/common/other/BasePanel.vue';
+import FormatAddress from '~/components/common/formatters/FormatAddress.vue';
 
 export default Vue.extend({
     name: 'VaultLiquidationPanel',
@@ -48,10 +49,11 @@ export default Vue.extend({
         BaseButton,
         BasePanel,
         TextBlock,
+        FormatAddress,
     },
     props: {
-        vaultId: {
-            type: [Number, String],
+        vaultAddress: {
+            type: String,
             required: true,
         },
         network: {

--- a/frontend/components/vault/Vault.stories.js
+++ b/frontend/components/vault/Vault.stories.js
@@ -16,7 +16,7 @@ const common = {
     data() {
         return {
             vault: fakeVaultNotLiquidatedTransaction,
-            vaultId: fakeVaultLiquidatedTransaction.id.toString(),
+            vaultAddress: fakeVaultLiquidatedTransaction.address,
         };
     },
     methods: {
@@ -27,25 +27,25 @@ const common = {
 storiesOf('Vault/Vault', module)
     .add('Default', () => ({
         ...common,
-        template: `<Vault :vaultTransaction="vault" :vaultId='vaultId' @liquidate="liquidate" />`,
+        template: `<Vault :vaultTransaction="vault" :vaultAddress='vaultAddress' @liquidate="liquidate" />`,
     }))
     .add('Finished', () => ({
         ...common,
         data() {
             return {
                 vault: fakeVaultLiquidatedTransaction,
-                vaultId: fakeVaultLiquidatedTransaction.id.toString(),
+                vaultAddress: fakeVaultLiquidatedTransaction.address,
             };
         },
-        template: `<Vault :vaultTransaction="vault" :vaultId='vaultId' @liquidate="liquidate" />`,
+        template: `<Vault :vaultTransaction="vault" :vaultAddress='vaultAddress' @liquidate="liquidate" />`,
     }))
     .add('Fetching', () => ({
         ...common,
-        template: `<Vault :are-vaults-fetching='true' :vaultId='vaultId' />`,
+        template: `<Vault :are-vaults-fetching='true' :vaultAddress='vaultAddress' />`,
     }))
     .add('Not found', () => ({
         ...common,
-        template: `<Vault :vaultId='vaultId' />`,
+        template: `<Vault :vaultAddress='vaultAddress' />`,
     }))
     .add('Invalid Date', () => ({
         ...common,
@@ -55,8 +55,8 @@ storiesOf('Vault/Vault', module)
                     ...fakeVaultNotLiquidatedTransaction,
                     nextPriceChange: 'Invalid Date',
                 },
-                vaultId: fakeVaultLiquidatedTransaction.id.toString(),
+                vaultAddress: fakeVaultLiquidatedTransaction.address,
             };
         },
-        template: `<Vault :vaultTransaction="vault" :vaultId='vaultId' @liquidate="liquidate" />`,
+        template: `<Vault :vaultTransaction="vault" :vaultAddress='vaultAddress' @liquidate="liquidate" />`,
     }));

--- a/frontend/components/vault/Vault.vue
+++ b/frontend/components/vault/Vault.vue
@@ -1,5 +1,8 @@
 <template>
-    <TextBlock :title="`Vault #${vaultId}`">
+    <TextBlock>
+        <template #title>
+            <span>Vault &nbsp;<FormatAddress shorten disable :value="vaultAddress" /></span>
+        </template>
         <div class="my-3">
             <Alert v-if="vaultError && vaultError.showBanner" :message="vaultError.error" type="error" />
         </div>
@@ -221,7 +224,7 @@ export default Vue.extend({
         LoadingIcon,
     },
     props: {
-        vaultId: {
+        vaultAddress: {
             type: String,
             required: true,
         },

--- a/frontend/components/vault/VaultFlow.stories.js
+++ b/frontend/components/vault/VaultFlow.stories.js
@@ -17,7 +17,7 @@ const common = {
     data() {
         return {
             vaultTransactions,
-            selectedVaultId: vaultTransactions[1].id.toString(),
+            selectedVaultAddress: vaultTransactions[1].address,
 
             vaultTransaction: generateFakeVaultNotLiquidatedTransaction(),
             liquidationLimits: generateFakeLiquidationLimits(),
@@ -99,7 +99,7 @@ storiesOf('Vault/VaultFlow', module)
         data() {
             return {
                 ...common.data(),
-                selectedVaultId: vaultTransactions[0].id.toString(),
+                selectedVaultAddress: vaultTransactions[0].address,
             };
         },
     }))
@@ -108,7 +108,7 @@ storiesOf('Vault/VaultFlow', module)
         data() {
             return {
                 ...common.data(),
-                selectedVaultId: vaultTransactions[0].id.toString(),
+                selectedVaultAddress: vaultTransactions[0].address,
                 isExplanationsShown: false,
             };
         },

--- a/frontend/components/vault/VaultFlow.vue
+++ b/frontend/components/vault/VaultFlow.vue
@@ -12,9 +12,9 @@
             <template #step1>
                 <div>
                     <Vault
-                        v-if="selectedVaultId"
+                        v-if="selectedVaultAddress"
                         class="mt-6 mb-8 mx-8"
-                        :vault-id="selectedVaultId"
+                        :vault-address="selectedVaultAddress"
                         :vault-transaction="selectedVaultTransaction"
                         :error="vaultsError"
                         :are-vaults-fetching="areVaultsFetching"
@@ -80,7 +80,7 @@ export default Vue.extend({
             type: String,
             default: null,
         },
-        selectedVaultId: {
+        selectedVaultAddress: {
             type: String,
             default: null,
         },
@@ -136,16 +136,16 @@ export default Vue.extend({
         selectedVaultTransaction(): VaultTransaction | null {
             return (
                 this.vaultTransactions.find(
-                    vaultTransaction => vaultTransaction.id.toString() === this.selectedVaultId
+                    vaultTransaction => vaultTransaction.address.toString() === this.selectedVaultAddress
                 ) || null
             );
         },
     },
     watch: {
-        selectedVaultId: {
+        selectedVaultAddress: {
             immediate: true,
-            handler(newSelectedVaultId) {
-                if (!newSelectedVaultId) {
+            handler(newSelectedVaultAddress) {
+                if (!newSelectedVaultAddress) {
                     this.step = 0;
                 } else {
                     this.step = 1;
@@ -156,7 +156,7 @@ export default Vue.extend({
             immediate: true,
             handler(newStep) {
                 if (newStep === 0) {
-                    this.$emit('update:selectedVaultId', null);
+                    this.$emit('update:selectedVaultAddress', null);
                 }
             },
         },

--- a/frontend/components/vault/VaultLiquidationTransactionFlow.vue
+++ b/frontend/components/vault/VaultLiquidationTransactionFlow.vue
@@ -66,7 +66,7 @@
                 @refreshLimits="$emit('refreshLimits')"
             />
             <VaultLiquidationPanel
-                :vault-id="vaultTransaction.id"
+                :vault-address="vaultTransaction.address"
                 :network="vaultTransaction.network"
                 :vault-state="vaultTransaction.state"
                 :wallet-address="walletAddress"

--- a/frontend/components/vault/VaultsTable.stories.js
+++ b/frontend/components/vault/VaultsTable.stories.js
@@ -10,7 +10,7 @@ const common = {
     components: { VaultsTable },
     data: () => ({
         vaultTransactions: fakeVaultTransaction,
-        selectedVaultId: randomSelectedVault.id,
+        selectedVaultAddress: randomSelectedVault.address,
         lastUpdated: new Date(faker.date.recent()),
         isLoading: false,
     }),
@@ -20,7 +20,7 @@ storiesOf('Vault/VaultsTable', module)
     .add('Plain', () => ({
         ...common,
         template:
-            '<VaultsTable :vaultTransactions="vaultTransactions" :selectedVaultId="selectedVaultId" :last-updated="lastUpdated" />',
+            '<VaultsTable :vaultTransactions="vaultTransactions" :selectedVaultAddress="selectedVaultAddress" :last-updated="lastUpdated" />',
     }))
     .add('Reset Updated Timer', () => ({
         ...common,
@@ -34,7 +34,7 @@ storiesOf('Vault/VaultsTable', module)
             }, 10 * 1000);
         },
         template:
-            '<VaultsTable :vaultTransactions="vaultTransactions" :selectedVaultId="selectedVaultId" :last-updated="lastUpdated" :is-loading="isLoading" />',
+            '<VaultsTable :vaultTransactions="vaultTransactions" :selectedVaultAddress="selectedVaultAddress" :last-updated="lastUpdated" :is-loading="isLoading" />',
     }))
     .add('Fetching With Vaults', () => ({
         ...common,
@@ -56,5 +56,5 @@ storiesOf('Vault/VaultsTable', module)
     .add('Expert Mode', () => ({
         ...common,
         template:
-            '<VaultsTable :vaultTransactions="vaultTransactions" :selectedVaultId="selectedVaultId" show-more-rows :last-updated="lastUpdated" />',
+            '<VaultsTable :vaultTransactions="vaultTransactions" :selectedVaultAddress="selectedVaultAddress" show-more-rows :last-updated="lastUpdated" />',
     }));

--- a/frontend/components/vault/VaultsTable.vue
+++ b/frontend/components/vault/VaultsTable.vue
@@ -6,7 +6,7 @@
             :columns="columns"
             :pagination="{ pageSize: numberOfRowsPerPage, hideOnSinglePage: true }"
             :row-class-name="getRowClassNames"
-            :row-key="record => record.id"
+            :row-key="record => record.address"
             :custom-row="customRowEvents"
             :get-popup-container="() => $el"
             :locale="{ emptyText: 'There are currently no vaults at risk.' }"
@@ -114,8 +114,8 @@ export default Vue.extend({
             type: Array as PropType<VaultTransaction[]>,
             default: () => [],
         },
-        selectedVaultId: {
-            type: Number,
+        selectedVaultAddress: {
+            type: String,
             default: null,
         },
         showMoreRows: {
@@ -150,9 +150,9 @@ export default Vue.extend({
             }));
             return [
                 {
-                    title: 'Index',
-                    dataIndex: 'id',
-                    sorter: compareBy('id'),
+                    title: 'Address',
+                    dataIndex: 'address',
+                    sorter: compareBy('address'),
                 },
                 {
                     title: 'Collateral amount',
@@ -211,7 +211,7 @@ export default Vue.extend({
         },
         getRowClassNames(vault: VaultTransaction) {
             const classes = [];
-            if (this.selectedVaultId === vault.id) {
+            if (this.selectedVaultAddress === vault.address) {
                 classes.push('selected-row');
             }
             if (!this.getIsVaultFinished(vault)) {

--- a/frontend/components/vault/VaultsText.stories.js
+++ b/frontend/components/vault/VaultsText.stories.js
@@ -10,7 +10,7 @@ const common = {
     components: { VaultsText },
     data: () => ({
         vaultTransactions: fakeVaults,
-        selectedVaultId: randomSelectedVault.id,
+        selectedVaultAddress: randomSelectedVault.address,
     }),
 };
 
@@ -21,12 +21,12 @@ storiesOf('Vault/VaultsText', module)
     }))
     .add('With vaults', () => ({
         ...common,
-        template: '<VaultsText :vaultTransactions="vaultTransactions" :selectedVaultId="selectedVaultId" />',
+        template: '<VaultsText :vaultTransactions="vaultTransactions" :selectedVaultAddress="selectedVaultAddress" />',
     }))
     .add('Fetching with Vaults', () => ({
         ...common,
         template:
-            '<VaultsText :vaultTransactions="vaultTransactions" :selectedVaultId="selectedVaultId" :isVaultsLoading="true" />',
+            '<VaultsText :vaultTransactions="vaultTransactions" :selectedVaultAddress="selectedVaultAddress" :isVaultsLoading="true" />',
     }))
     .add('Fetching without Vaults', () => ({
         ...common,
@@ -39,7 +39,7 @@ storiesOf('Vault/VaultsText', module)
     .add('Expert Mode', () => ({
         ...common,
         template:
-            '<VaultsText :vaultTransactions="vaultTransactions" :selectedVaultId="selectedVaultId" :isExplanationsShown="false" />',
+            '<VaultsText :vaultTransactions="vaultTransactions" :selectedVaultAddress="selectedVaultAddress" :isExplanationsShown="false" />',
     }))
     .add('No props', () => ({
         ...common,

--- a/frontend/components/vault/VaultsText.vue
+++ b/frontend/components/vault/VaultsText.vue
@@ -40,23 +40,24 @@
             :class="{ 'max-w-4xl': isExplanationsShown, 'md:px-10': !isExplanationsShown }"
         >
             <Alert type="info" show-icon>
-                <div slot="message" class="font-bold">Specific vault id is required</div>
+                <div slot="message" class="font-bold">Specific vault address is required</div>
                 <template slot="description">
                     <TextBlock>
-                        Please provide a specific vault id to see its state. To find vaults that are currently at risk
-                        and can be liquidated, please follow to the
-                        <a href="https://maker.blockanalitica.com/vaults-at-risk/" target="_blank">blockanalitica</a>
-                        page.
+                        Please provide a specific Sky vault address to see its state and be able to liquidate it. To
+                        find currently active vaults please check relevant BlockAnalitica pages:
+                        <a href="https://info.sky.money/collateral/core/cdps" target="_blank">Core Vaults</a>,
+                        <a href="https://info.sky.money/collateral/seal-engine/cdps" target="_blank"
+                            >Seal Engine Vaults</a
+                        >.
                     </TextBlock>
                 </template>
             </Alert>
             <div>
                 <div style="margin-bottom: 16px" class="mt-4">
                     <Input
-                        v-model="inputVaultId"
-                        type="number"
+                        v-model="inputVaultAddress"
                         size="large"
-                        placeholder="Enter a vault id"
+                        placeholder="Enter vault address"
                         onkeydown="return event.keyCode !== 69 && event.keyCode !== 188"
                     >
                         <nuxt-link slot="addonAfter" :to="vaultInputLink"> View vault </nuxt-link>
@@ -121,12 +122,15 @@ export default Vue.extend({
     },
     data() {
         return {
-            inputVaultId: 28187,
+            inputVaultAddress: '',
         };
     },
     computed: {
         vaultInputLink(): string {
-            const searchParams = new URLSearchParams({ network: this.network, vault: this.inputVaultId.toString() });
+            const searchParams = new URLSearchParams({
+                network: this.network,
+                vault: this.inputVaultAddress,
+            });
             return `/vaults?${searchParams.toString()}`;
         },
         vaultsReadyToBeLiquidated(): number {

--- a/frontend/components/vault/VaultsText.vue
+++ b/frontend/components/vault/VaultsText.vue
@@ -68,7 +68,7 @@
                 v-if="vaultTransactions && vaultTransactions.length !== 0"
                 :vault-transactions="vaultTransactions"
                 :show-more-rows="isExplanationsShown"
-                :selected-vault-id="selectedVaultId"
+                :selected-vault-address="selectedVaultAddress"
                 :last-updated="lastUpdated"
             />
         </div>
@@ -103,8 +103,8 @@ export default Vue.extend({
             type: String,
             default: null,
         },
-        selectedVaultId: {
-            type: Number,
+        selectedVaultAddress: {
+            type: String,
             default: null,
         },
         isExplanationsShown: {

--- a/frontend/containers/VaultsContainer.vue
+++ b/frontend/containers/VaultsContainer.vue
@@ -4,7 +4,7 @@
             :vault-transactions="vaultTransactions"
             :are-vaults-fetching="areVaultsLoading"
             :is-liquidating="isVaultBeingLiquidated"
-            :selected-vault-id.sync="selectedVaultId"
+            :selected-vault-address.sync="selectedVaultAddress"
             :is-connecting-wallet="isWalletLoading"
             :dai-vat-balance="daiVatBalance"
             :is-authorizing="isAuthorizing"
@@ -63,7 +63,7 @@ export default Vue.extend({
             isLiquidated: 'isVaultLiquidationDone',
             lastUpdated: 'getLastUpdated',
         }),
-        selectedVaultId: {
+        selectedVaultAddress: {
             get(): string | null {
                 const vaultsGetParameter = this.$route.query.vault;
                 if (Array.isArray(vaultsGetParameter)) {
@@ -92,7 +92,7 @@ export default Vue.extend({
         },
     },
     watch: {
-        selectedVaultId: {
+        selectedVaultAddress: {
             immediate: true,
             handler(): void {
                 this.fetchSelectedVault();
@@ -111,7 +111,7 @@ export default Vue.extend({
         },
         liquidate(walletAddress: string): void {
             this.$store.dispatch('vaults/liquidateVault', {
-                vaultId: this.selectedVaultId,
+                vaultAddress: this.selectedVaultAddress,
                 walletAddress,
             });
         },

--- a/frontend/helpers/generateFakeVault.ts
+++ b/frontend/helpers/generateFakeVault.ts
@@ -17,13 +17,10 @@ import BigNumber from 'bignumber.js';
 import { random } from 'lodash';
 
 const generateFakeVaultBase = function (): VaultBase {
-    const id = faker.datatype.number();
     const address = faker.finance.ethereumAddress();
     const collateralType = faker.helpers.randomize(Object.keys(COLLATERALS));
     const network = 'mainnet';
-
     return {
-        id,
         address,
         collateralType,
         network,

--- a/frontend/store/vaults.ts
+++ b/frontend/store/vaults.ts
@@ -81,9 +81,9 @@ export const actions = {
         refetchIntervalId = setInterval(() => dispatch('updateSelectedVault'), REFETCH_INTERVAL);
     },
     async updateSelectedVault({ rootState, dispatch }: ActionContext<State, any>) {
-        const selectedVaultId = rootState.route.query.vault;
-        if (selectedVaultId) {
-            await dispatch('fetchVault', selectedVaultId);
+        const selectedVaultAddress = rootState.route.query.vault;
+        if (selectedVaultAddress) {
+            await dispatch('fetchVault', selectedVaultAddress);
         }
     },
     async fetchVault({ commit, rootGetters }: ActionContext<State, State>, vaultAddress: string) {


### PR DESCRIPTION
Adds possibility to liquidate vault by it's address, also updates wording and links on the `/vaults` page.


The data about the vault is fetched
<img width="1438" alt="Screenshot 2024-11-20 at 17 09 07" src="https://github.com/user-attachments/assets/7b83c3b8-57de-46d4-9f1c-ca34aa390784">

Vault liquidation transaction page
<img width="1438" alt="Screenshot 2024-11-20 at 17 24 12" src="https://github.com/user-attachments/assets/0a0d2c62-95a3-42ee-bd7e-0eab3fac339d">

Vault liquidation after successful liquidation
<img width="1436" alt="Screenshot 2024-11-20 at 17 25 09" src="https://github.com/user-attachments/assets/18014a8f-0c5b-4aea-b8ee-c1324cfd594c">
