### PR TITLE
Update UniswapV2LockstakeCallee address

### DIFF
--- a/bot/src/keepers/collateral.ts
+++ b/bot/src/keepers/collateral.ts
@@ -1,7 +1,7 @@
 import { AuctionInitialInfo } from 'auctions-core/src/types';
 import { bidWithCallee, enrichAuction } from 'auctions-core/src/auctions';
 import getSigner from 'auctions-core/src/signer';
-import { fetchVATbalanceDAI, fetchBalanceDAI } from 'auctions-core/src/wallet';
+import { fetchVATbalanceDAI, fetchBalanceDAI, fetchBalanceUSDS } from 'auctions-core/src/wallet';
 import { KEEPER_COLLATERAL_MINIMUM_NET_PROFIT_DAI } from '../variables';
 import { checkAndAuthorizeCollateral, checkAndAuthorizeWallet } from '../authorisation';
 import { setupWallet } from '../signer';
@@ -115,6 +115,7 @@ const checkAndParticipateIfPossible = async function (network: string, auction: 
     // save previous balances
     const preVatBalanceDai = await fetchVATbalanceDAI(network, walletAddress);
     const preErcBalanceDai = await fetchBalanceDAI(network, walletAddress);
+    const preErcBalanceUsds = await fetchBalanceUSDS(network, walletAddress);
 
     // bid on the Auction
     console.info(`collateral keeper: auction "${auctionTransaction.id}": attempting swap execution`);
@@ -131,8 +132,10 @@ const checkAndParticipateIfPossible = async function (network: string, auction: 
     // display profit
     const postVatBalanceDai = await fetchVATbalanceDAI(network, walletAddress);
     const postErcBalanceDai = await fetchBalanceDAI(network, walletAddress);
-    console.info(`DAI VAT   profit from the transaction: ${postVatBalanceDai.minus(preVatBalanceDai).toFixed()}`);
-    console.info(`DAI ERC20 profit from the transaction: ${postErcBalanceDai.minus(preErcBalanceDai).toFixed()}`);
+    const postErcBalanceUsds = await fetchBalanceUSDS(network, walletAddress);
+    console.info(`DAI  VAT   profit from the transaction: ${postVatBalanceDai.minus(preVatBalanceDai).toFixed()}`);
+    console.info(`DAI  ERC20 profit from the transaction: ${postErcBalanceDai.minus(preErcBalanceDai).toFixed()}`);
+    console.info(`USDS ERC20 profit from the transaction: ${postErcBalanceUsds.minus(preErcBalanceUsds).toFixed()}`);
 };
 
 const participateInAuction = async function (network: string, auction: AuctionInitialInfo) {

--- a/core/simulations/configs/vaultLiquidation.ts
+++ b/core/simulations/configs/vaultLiquidation.ts
@@ -42,8 +42,6 @@ const simulation: Simulation = {
         {
             title: 'Create underwater vault',
             entry: async context => {
-                // set oracle price
-                await overwriteCurrentOraclePrice(TEST_NETWORK, context.collateralType, new BigNumber(1000));
                 const initialOraclePrice = await getCurrentOraclePriceByCollateralType(
                     TEST_NETWORK,
                     context.collateralType

--- a/core/src/constants/CALLEES.ts
+++ b/core/src/constants/CALLEES.ts
@@ -11,7 +11,7 @@ const CALLEES: Record<string, CalleeAddresses | undefined> = {
         UniswapV3Callee: '0xdB9C76109d102d2A1E645dCa3a7E671EBfd8e11A',
         rETHCurveUniv3Callee: '0x7cdAb0fE16efb1EFE89e53B141347D7F299d6610',
         OneInchCallee: '0x19c916CDAFB41FAdd4CEd3dCf412e0302291563A',
-        UniswapV2LockstakeCallee: '0xf68424845e4Af5b771356d504965A3c9257805f3',
+        UniswapV2LockstakeCallee: '0x047b6a135fae4344c70da9dd60baa57c5b8073a0',
     },
     '0x5': {
         UniswapV2CalleeDai: '0x6d9139ac89ad2263f138633de20e47bcae253938',

--- a/core/src/contracts.ts
+++ b/core/src/contracts.ts
@@ -56,6 +56,7 @@ export const getContractAddressByName = async function (network: string, contrac
 export const getContractInterfaceByName = async function (contractName: string): Promise<ContractInterface> {
     const ABIs: Record<string, ContractInterface> = {
         MCD_DAI,
+        USDS: MCD_DAI,
         MCD_VOW,
         MCD_VAT,
         MCD_DOG,

--- a/core/src/wallet.ts
+++ b/core/src/wallet.ts
@@ -25,6 +25,12 @@ export const fetchBalanceDAI = async function (network: string, walletAddress: s
     return new BigNumber(rawAmount._hex).shiftedBy(-DAI_NUMBER_OF_DIGITS);
 };
 
+export const fetchBalanceUSDS = async function (network: string, walletAddress: string): Promise<BigNumber> {
+    const contract = await getContract(network, 'USDS');
+    const rawAmount = await contract.balanceOf(walletAddress);
+    return new BigNumber(rawAmount._hex).shiftedBy(-WAD_NUMBER_OF_DIGITS);
+};
+
 export const fetchBalanceMKR = async function (network: string, walletAddress: string): Promise<BigNumber> {
     const contract = await getContract(network, 'MKR');
     const rawAmount = await contract.balanceOf(walletAddress);


### PR DESCRIPTION
This PR updates `UniswapV2LockstakeCallee` address. The callee had to be updated as the previous callee depended on the legacy `MKR_SKY` converter that no longer works