### PR TITLE
fix: add debt type to fake auction

### DIFF
--- a/frontend/helpers/generateFakeAuction.ts
+++ b/frontend/helpers/generateFakeAuction.ts
@@ -119,6 +119,7 @@ export const generateFakeAuction = function () {
         collateralAmount,
         totalPrice,
         debtDAI,
+        debtType: collateralObject.debtType,
         initialPrice: approximateUnitPrice,
         endDate: faker.date.future(),
         marketUnitPriceToUnitPriceRatio,


### PR DESCRIPTION
Closes N/A

Fix generating fake auctions

Local rebuild:
```bash
cd frontend
npm run preinstall
npm run generate
```

Checklist:
- ~~[ ] issue number linked above after pound (`#`)~~
    - replace "Closes " with "Contributes to" or other if this PR does not close the issue
- ~~[ ] issue checkboxes are all addressed~~
- ~~[ ] manually checked my feature / not applicable~~
- ~~[ ] wrote tests / not applicable~~
- ~~[ ] attached screenshots / not applicable~~
