### PR TITLE
ci: switch staging build to Blacksmith multi-arch

### DIFF
--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -2,7 +2,7 @@ name: Deploy Auctions UI staging
 
 on:
   push:
-    branches: [ main, ci/staging-blacksmith-multiarch ]
+    branches: [ main]
 
 jobs:
   build-frontend:
@@ -155,7 +155,6 @@ jobs:
 
   deploy:
     name: deploy staging to cluster
-    if: false
     needs:
       - merge-frontend
       - merge-bot

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -2,23 +2,30 @@ name: Deploy Auctions UI staging
 
 on:
   push:
-    branches: [ main ]
+    branches: [ main, ci/staging-blacksmith-multiarch ]
 
 jobs:
   build-frontend:
-    name: build frontend
-    runs-on: ubuntu-latest
+    name: build frontend ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+            tag: amd64
+          - platform: linux/arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            tag: arm64
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+    - name: Setup Docker Builder
+      uses: useblacksmith/setup-docker-builder@v1
 
     - name: Login to GitHub Packages
       uses: docker/login-action@v3
@@ -33,25 +40,21 @@ jobs:
         aws-region: eu-central-1
         role-to-assume: arn:aws:iam::802385070966:role/GithubActionsSSMRole
         role-session-name: AuctionsUiSession
-  
+
     - name: Get secrets from parameterstore
       uses: dkershner6/aws-ssm-getparameters-action@v2
       with:
         parameterPairs: "/auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/rpc_url = RPC_URL, /auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/contact_email = CONTACT_EMAIL, /auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/frontend_origin = FRONTEND_ORIGIN, /auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/infura_project_id = INFURA_POJECT_ID, /auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/heapio_id = HEAPIO_ID, /auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/production_domain = PRODUCTION_DOMAIN, /auction-ui/main.auction-ui.k8s.sidestream.tech/frontend/staging_banner_url = STAGING_BANNER_URL"
         withDecryption: "true"
 
-    - name: Set outputs
-      id: vars
-      run: echo "git_hash_short=$(git rev-parse --short ${GITHUB_SHA})" >> $GITHUB_OUTPUT
-
     - name: build and push frontend
-      uses: docker/build-push-action@v6
+      uses: useblacksmith/build-push-action@v2
       with:
         file: frontend/Dockerfile
         context: ./
-        platforms: linux/amd64
+        platforms: ${{ matrix.platform }}
         tags: |
-          ghcr.io/sidestream-tech/unified-auctions-ui/frontend-staging:${{ github.sha }}
+          ghcr.io/sidestream-tech/unified-auctions-ui/frontend-staging:${{ github.sha }}-${{ matrix.tag }}
         build-args: |
           RPC_URL=${{ env.RPC_URL }}
           PRODUCTION_DOMAIN=${{ env.PRODUCTION_DOMAIN }}
@@ -61,20 +64,52 @@ jobs:
           FRONTEND_ORIGIN=${{ env.FRONTEND_ORIGIN }}
         push: true
 
-  build-bot:
-    name: build bot
-    runs-on: ubuntu-latest
+  merge-frontend:
+    name: merge and push frontend manifest
+    runs-on: blacksmith
     permissions: write-all
+    needs: build-frontend
+
+    steps:
+    - name: Login to GitHub Packages
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.GH_WORKFLOW_USER }}
+        password: ${{ secrets.GH_WORKFLOW_TOKEN }}
+
+    - name: Setup Docker Builder
+      uses: useblacksmith/setup-docker-builder@v1
+
+    - name: Create and push multi-arch manifest
+      run: |
+        docker buildx imagetools create \
+          --tag ghcr.io/sidestream-tech/unified-auctions-ui/frontend-staging:${{ github.sha }} \
+          --tag ghcr.io/sidestream-tech/unified-auctions-ui/frontend-staging:main \
+          ghcr.io/sidestream-tech/unified-auctions-ui/frontend-staging:${{ github.sha }}-amd64 \
+          ghcr.io/sidestream-tech/unified-auctions-ui/frontend-staging:${{ github.sha }}-arm64
+
+  build-bot:
+    name: build bot ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+            tag: amd64
+          - platform: linux/arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            tag: arm64
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+    - name: Setup Docker Builder
+      uses: useblacksmith/setup-docker-builder@v1
 
     - name: Login to GitHub Packages
       uses: docker/login-action@v3
@@ -83,25 +118,47 @@ jobs:
         username: ${{ secrets.GH_WORKFLOW_USER }}
         password: ${{ secrets.GH_WORKFLOW_TOKEN }}
 
-    - name: Set outputs
-      id: vars
-      run: echo "git_hash_short=$(git rev-parse --short ${GITHUB_SHA})" >> $GITHUB_OUTPUT
-    
     - name: build and push bot
-      uses: docker/build-push-action@v6
+      uses: useblacksmith/build-push-action@v2
       with:
         file: bot/Dockerfile
         context: ./
-        platforms: linux/amd64
+        platforms: ${{ matrix.platform }}
         tags: |
-          ghcr.io/sidestream-tech/unified-auctions-ui/bot-staging:${{ github.sha }}
+          ghcr.io/sidestream-tech/unified-auctions-ui/bot-staging:${{ github.sha }}-${{ matrix.tag }}
         push: true
+
+  merge-bot:
+    name: merge and push bot manifest
+    runs-on: blacksmith
+    permissions: write-all
+    needs: build-bot
+
+    steps:
+    - name: Login to GitHub Packages
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.GH_WORKFLOW_USER }}
+        password: ${{ secrets.GH_WORKFLOW_TOKEN }}
+
+    - name: Setup Docker Builder
+      uses: useblacksmith/setup-docker-builder@v1
+
+    - name: Create and push multi-arch manifest
+      run: |
+        docker buildx imagetools create \
+          --tag ghcr.io/sidestream-tech/unified-auctions-ui/bot-staging:${{ github.sha }} \
+          --tag ghcr.io/sidestream-tech/unified-auctions-ui/bot-staging:main \
+          ghcr.io/sidestream-tech/unified-auctions-ui/bot-staging:${{ github.sha }}-amd64 \
+          ghcr.io/sidestream-tech/unified-auctions-ui/bot-staging:${{ github.sha }}-arm64
 
   deploy:
     name: deploy staging to cluster
+    if: false
     needs:
-      - build-frontend
-      - build-bot
+      - merge-frontend
+      - merge-bot
     runs-on: ubuntu-latest
     steps:
       - name: Checkout k8s-projects Repo
@@ -112,27 +169,27 @@ jobs:
           path: k8s-projects
           ref: main
 
-      - uses: benjlevesque/short-sha@v2.2
+      - uses: benjlevesque/short-sha@v3.0
         id: short-sha
         with:
           length: 6
 
       - name: Update Auctions-UI Value File for frontend
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@v4.53.2
         with:
           cmd: yq -i '(.image.tag ="${{ github.sha }}") | (.commitShortSHA ="${{ github.sha }}") | (.releaseTag ="${{ github.ref_name }}")' $VALUES_FILE
         env:
           VALUES_FILE: "k8s-projects/auctions-ui/staging/values-frontend.yml"
 
       - name: Update Auctions-UI Value File for bot
-        uses: mikefarah/yq@master
+        uses: mikefarah/yq@v4.53.2
         with:
           cmd: yq -i '(.image.tag ="${{ github.sha }}") | (.commitShortSHA ="${{ github.sha }}") | (.releaseTag ="${{ github.ref_name }}")' $VALUES_FILE
         env:
           VALUES_FILE: "k8s-projects/auctions-ui/staging/values-bot.yml"
 
       - name: Commit & Push changes
-        uses: actions-js/push@master
+        uses: actions-js/push@v1.5
         with:
           github_token: ${{ secrets.GH_WORKFLOW_TOKEN }}
           repository: sidestream-tech/k8s-projects

--- a/.github/workflows/build-and-deploy-staging.yml
+++ b/.github/workflows/build-and-deploy-staging.yml
@@ -2,7 +2,7 @@ name: Deploy Auctions UI staging
 
 on:
   push:
-    branches: [ main]
+    branches: [ main ]
 
 jobs:
   build-frontend:


### PR DESCRIPTION
## Summary
- Replace the single-arch staging build with a matrix build on Blacksmith runners (`linux/amd64` + `linux/arm64`) using `useblacksmith/setup-docker-builder@v1` and `useblacksmith/build-push-action@v2`, mirroring the pipeline approach of other sidestream projects.
- Add per-image manifest-merge jobs (`merge-frontend`, `merge-bot`) that publish multi-arch manifests under `:${sha}` and `:main` via `docker buildx imagetools create`.
- Pin deploy-step actions to exact versions (`benjlevesque/short-sha@v3.0`, `mikefarah/yq@v4.53.2`, `actions-js/push@v1.5`).

## Status
The build path has been **tested successfully end-to-end on this branch**: both `build-frontend` and `build-bot` matrix legs ran on Blacksmith amd64 + arm64, and `merge-frontend` / `merge-bot` published the multi-arch manifests. The temporary CI branch trigger and the `if: false` gate on the `deploy` job have been removed — the workflow is back to its production shape and ready to run on merge to `main`.

## Test plan
- [x] Push to this branch triggers the workflow and both `build-frontend` and `build-bot` matrix legs succeed on Blacksmith amd64 + arm64 runners.
- [x] `merge-frontend` and `merge-bot` publish multi-arch manifests at `ghcr.io/sidestream-tech/unified-auctions-ui/frontend-staging:${sha}` and `:main` (and equivalent for `bot-staging`).
- [x] Branch trigger and `if: false` reverted before merge.