### PR TITLE
Build multi-arch production images (amd64 + arm64)

### DIFF
--- a/.github/workflows/build-and-deploy-production.yml
+++ b/.github/workflows/build-and-deploy-production.yml
@@ -6,19 +6,26 @@ on:
 
 jobs:
   build-frontend:
-    name: build frontend
-    runs-on: ubuntu-latest
+    name: build frontend ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
     permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+            tag: amd64
+          - platform: linux/arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            tag: arm64
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+    - name: Setup Docker Builder
+      uses: useblacksmith/setup-docker-builder@v1
 
     - name: Login to GitHub Packages
       uses: docker/login-action@v3
@@ -33,25 +40,21 @@ jobs:
         aws-region: eu-central-1
         role-to-assume: arn:aws:iam::802385070966:role/GithubActionsSSMRole
         role-session-name: AuctionsUiSession
-  
+
     - name: Get secrets from parameterstore
       uses: dkershner6/aws-ssm-getparameters-action@v2
       with:
         parameterPairs: "/auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/rpc_url = RPC_URL, /auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/contact_email = CONTACT_EMAIL, /auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/frontend_origin = FRONTEND_ORIGIN, /auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/infura_project_id = INFURA_POJECT_ID, /auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/heapio_id = HEAPIO_ID, /auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/production_domain = PRODUCTION_DOMAIN, /auction-ui/production.auction-ui.k8s.sidestream.tech/frontend/staging_banner_url = STAGING_BANNER_URL"
         withDecryption: "true"
 
-    - name: Set outputs
-      id: vars
-      run: echo "git_hash_short=$(git rev-parse --short ${GITHUB_SHA})" >> $GITHUB_OUTPUT
-
     - name: build and push frontend
-      uses: docker/build-push-action@v6
+      uses: useblacksmith/build-push-action@v2
       with:
         file: frontend/Dockerfile
         context: ./
-        platforms: linux/amd64
+        platforms: ${{ matrix.platform }}
         tags: |
-          ghcr.io/sidestream-tech/unified-auctions-ui/frontend-prod:${{ github.sha }}
+          ghcr.io/sidestream-tech/unified-auctions-ui/frontend-prod:${{ github.sha }}-${{ matrix.tag }}
         build-args: |
           RPC_URL=${{ env.RPC_URL }}
           PRODUCTION_DOMAIN=${{ env.PRODUCTION_DOMAIN }}
@@ -61,20 +64,51 @@ jobs:
           FRONTEND_ORIGIN=${{ env.FRONTEND_ORIGIN }}
         push: true
 
-  build-bot:
-    name: build bot
-    runs-on: ubuntu-latest
+  merge-frontend:
+    name: merge and push frontend manifest
+    runs-on: blacksmith
     permissions: write-all
+    needs: build-frontend
+
+    steps:
+    - name: Login to GitHub Packages
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.GH_WORKFLOW_USER }}
+        password: ${{ secrets.GH_WORKFLOW_TOKEN }}
+
+    - name: Setup Docker Builder
+      uses: useblacksmith/setup-docker-builder@v1
+
+    - name: Create and push multi-arch manifest
+      run: |
+        docker buildx imagetools create \
+          --tag ghcr.io/sidestream-tech/unified-auctions-ui/frontend-prod:${{ github.sha }} \
+          ghcr.io/sidestream-tech/unified-auctions-ui/frontend-prod:${{ github.sha }}-amd64 \
+          ghcr.io/sidestream-tech/unified-auctions-ui/frontend-prod:${{ github.sha }}-arm64
+
+  build-bot:
+    name: build bot ${{ matrix.platform }}
+    runs-on: ${{ matrix.runner }}
+    permissions: write-all
+    strategy:
+      fail-fast: false
+      matrix:
+        include:
+          - platform: linux/amd64
+            runner: blacksmith-4vcpu-ubuntu-2404
+            tag: amd64
+          - platform: linux/arm64
+            runner: blacksmith-4vcpu-ubuntu-2404-arm
+            tag: arm64
 
     steps:
     - name: Checkout
       uses: actions/checkout@v4
 
-    - name: Set up QEMU
-      uses: docker/setup-qemu-action@v3
-
-    - name: Set up Docker Buildx
-      uses: docker/setup-buildx-action@v3
+    - name: Setup Docker Builder
+      uses: useblacksmith/setup-docker-builder@v1
 
     - name: Login to GitHub Packages
       uses: docker/login-action@v3
@@ -83,25 +117,45 @@ jobs:
         username: ${{ secrets.GH_WORKFLOW_USER }}
         password: ${{ secrets.GH_WORKFLOW_TOKEN }}
 
-    - name: Set outputs
-      id: vars
-      run: echo "git_hash_short=$(git rev-parse --short ${GITHUB_SHA})" >> $GITHUB_OUTPUT
-    
     - name: build and push bot
-      uses: docker/build-push-action@v6
+      uses: useblacksmith/build-push-action@v2
       with:
         file: bot/Dockerfile
         context: ./
-        platforms: linux/amd64
+        platforms: ${{ matrix.platform }}
         tags: |
-          ghcr.io/sidestream-tech/unified-auctions-ui/bot-prod:${{ github.sha }}
+          ghcr.io/sidestream-tech/unified-auctions-ui/bot-prod:${{ github.sha }}-${{ matrix.tag }}
         push: true
+
+  merge-bot:
+    name: merge and push bot manifest
+    runs-on: blacksmith
+    permissions: write-all
+    needs: build-bot
+
+    steps:
+    - name: Login to GitHub Packages
+      uses: docker/login-action@v3
+      with:
+        registry: ghcr.io
+        username: ${{ secrets.GH_WORKFLOW_USER }}
+        password: ${{ secrets.GH_WORKFLOW_TOKEN }}
+
+    - name: Setup Docker Builder
+      uses: useblacksmith/setup-docker-builder@v1
+
+    - name: Create and push multi-arch manifest
+      run: |
+        docker buildx imagetools create \
+          --tag ghcr.io/sidestream-tech/unified-auctions-ui/bot-prod:${{ github.sha }} \
+          ghcr.io/sidestream-tech/unified-auctions-ui/bot-prod:${{ github.sha }}-amd64 \
+          ghcr.io/sidestream-tech/unified-auctions-ui/bot-prod:${{ github.sha }}-arm64
 
   deploy:
     name: deploy production to cluster
     needs:
-      - build-frontend
-      - build-bot
+      - merge-frontend
+      - merge-bot
     runs-on: ubuntu-latest
     steps:
       - name: Checkout k8s-projects Repo


### PR DESCRIPTION
Production images (frontend + bot) are currently amd64-only. The `production-spot` node pool is being switched to ARM (Graviton) instances, so production builds need to produce arm64 images as well.

- Frontend and bot build jobs now run as a matrix on Blacksmith runners (`blacksmith-4vcpu-ubuntu-2404` / `-arm`), pushing per-arch tags `<sha>-amd64` / `<sha>-arm64`
- New `merge-frontend` / `merge-bot` jobs combine them into multi-arch manifests tagged `<sha>`
- Deploy job unchanged, now depends on the merge jobs
- SSM parameter fetching and build-args for the frontend kept as before

Mirrors the existing staging workflow, which already builds both architectures.